### PR TITLE
hotfix missing include url_helper in messenger template

### DIFF
--- a/app/models/messenger_template.rb
+++ b/app/models/messenger_template.rb
@@ -10,6 +10,7 @@
 #  updated_at :datetime         not null
 #
 class MessengerTemplate < Template
+  include Rails.application.routes.url_helpers
 
   def self.model_name
     Template.model_name


### PR DESCRIPTION
Fix missing include Rails url_helper in Messenger Template with image assets