### PR TITLE
Redirect created dictionary to edit

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -21,7 +21,7 @@ class DictionariesController < ApplicationController
     respond_to do |format|
       if @variable.save
         format.html { redirect_to dictionaries_path, status: :moved_permanently, notice: t("created.success") }
-        format.js
+        format.js { redirect_to edit_dictionary_path(@variable), status: :moved_permanently, notice: t("created.success") }
       else
         format.html { render :new, status: :unprocessable_entity, alert: t("created.fail") }
         format.js


### PR DESCRIPTION
Fix error undefined variable dictionary_counter:

render 'dictionary' in dictionaries/create.js.erb need to pass `dictionary_counter` (reused partial from render @dictionaries)
it is not make sense to append newly created dictionary on top because it is not consistent when reload the page (sort by name)
and also need to update column index (#) 

so I think it would be better to redirect user to dictionary edit action