### PR TITLE
fix(set language): cannot change language

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SettingsController < ApplicationController
-  before_action :authorize_setting
+  before_action :authorize_setting, except: :set_language
 
   def index
     @telegram_bot = TelegramBot.first || TelegramBot.new


### PR DESCRIPTION
Allow site admin and site ombudsman to change language

Currently, only system admin can do that