### PR TITLE
Fix static default message last_interaction_at

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
 
   def index
     authorize Message
-    collection = Message.filter(filter_options)
+    collection = Message.filter(filter_options).reorder(last_interaction_at: :desc)
 
     if current_user.system_admin?
       @variables = Variable.all

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -8,4 +8,14 @@ module HomeHelper
   def no_messages
     @messages.count == 0
   end
+
+  def render_from_string(str, size: "24x24")
+    return str if str.empty? || !valid_image?(str)
+
+    image_tag str, size: size
+  end
+
+  def valid_image?(url)
+    url =~ %r{.+\.(gif|jpe?g|png)}i
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,7 +5,7 @@
 #  id                  :bigint(8)        not null, primary key
 #  content_type        :string
 #  gender              :string           default("")
-#  last_interaction_at :datetime         default(Mon, 03 Aug 2020 10:01:25 +07 +07:00)
+#  last_interaction_at :datetime
 #  platform_name       :string           default("")
 #  repeated            :boolean          default(FALSE)
 #  status              :integer(4)       default("incomplete")

--- a/app/views/home/_message.html.haml
+++ b/app/views/home/_message.html.haml
@@ -13,8 +13,8 @@
   %td.border-left-0.border-bottom-0
     - result = []
     - step_values.each do |step|
-      - result << step.variable_value.mapping_value
-    = result.join(", ")
+      - result << render_from_string(step.variable_value.mapping_value)
+    = result.compact.join(", ").html_safe
   %td.border-left-0.border-right-0.border-bottom-0
     %span.timeago{ "data-full-datetime": display_datetime(message.last_interaction_at) }
       = time_ago_in_words(message.last_interaction_at)

--- a/db/migrate/20201209014012_change_message_last_interaction_at_datetime_default.rb
+++ b/db/migrate/20201209014012_change_message_last_interaction_at_datetime_default.rb
@@ -1,0 +1,7 @@
+class ChangeMessageLastInteractionAtDatetimeDefault < ActiveRecord::Migration[6.0]
+  def change
+    change_column :messages, :last_interaction_at, :datetime, default: -> { 'CURRENT_TIMESTAMP' }
+
+    Rake::Task["message:migrate_last_interaction_at"].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_26_104233) do
+ActiveRecord::Schema.define(version: 2020_12_09_014012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 2020_10_26_104233) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status", default: 0
     t.string "platform_name", default: ""
-    t.datetime "last_interaction_at", default: "2020-08-03 03:01:25"
+    t.datetime "last_interaction_at", default: -> { "CURRENT_TIMESTAMP" }
     t.string "province_id"
     t.string "district_id", limit: 8
     t.string "gender", default: ""


### PR DESCRIPTION
## Issue description:
When a message is cloned, ```last_interaction_at```  does not set to current date time, instead it sets with a static date.
that static date is the date that is provided by previous migration

__Old migration__
```
add_column :messages, :last_interaction_at, :datetime, default: Time.current # 2020-08-03 03:01:25
```

__New migration__
```
add_column :messages, :last_interaction_at, :datetime, default: -> { "CURRENT_TIMESTAMP" }
```
We have to set it in database level;
[Issue discussion](https://github.com/rails/rails/issues/27077)

## solution:
1. Use database level **CURRENT_TIMESTAMP** (pg knows how to deal)
2. Migrate old records
3. Order sessions by **last_interaction_at** column