### PR TITLE
Display clone location

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -67,8 +67,8 @@ class Message < ApplicationRecord
   end
 
   def clone_relations
-    step_values.clone_rel :gender, gender
-    step_values.clone_rel :location, district_id
+    step_values.clone_step :gender, gender
+    step_values.clone_step :location, district_id
     self
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -62,7 +62,14 @@ class Message < ApplicationRecord
     return self unless prev.present?
 
     attrs = prev.attributes.slice(*clone_attributes)
-    Message.create!(attrs.merge({ repeated: true }))
+    message = Message.create!(attrs.merge({ repeated: true }))
+    message.clone_relations
+  end
+
+  def clone_relations
+    step_values.clone_rel :gender, gender
+    step_values.clone_rel :location, district_id
+    self
   end
 
   def self.accessed(options = {})

--- a/app/models/step_value.rb
+++ b/app/models/step_value.rb
@@ -103,6 +103,12 @@ class StepValue < ApplicationRecord
     scope = filter(scope, params)
   end
 
+  def self.clone_rel(attr, value)
+    variable = Variable.send(attr)
+    variable_value = variable.values.find_by(raw_value: value)
+    create variable: variable, variable_value: variable_value
+  end
+
   private
     def self.feedback_column
       @feedback_column ||= Variable.feedback

--- a/app/models/step_value.rb
+++ b/app/models/step_value.rb
@@ -103,10 +103,12 @@ class StepValue < ApplicationRecord
     scope = filter(scope, params)
   end
 
-  def self.clone_rel(attr, value)
+  def self.clone_step(attr, value)
     variable = Variable.send(attr)
     variable_value = variable.values.find_by(raw_value: value)
     create variable: variable, variable_value: variable_value
+  rescue
+    nil
   end
 
   private

--- a/app/views/home/_message.html.haml
+++ b/app/views/home/_message.html.haml
@@ -12,7 +12,7 @@
       = message.session_id
   %td.border-left-0.border-bottom-0
     - result = []
-    - step_values.each do |step|
+    - step_values.order(:id).each do |step|
       - result << render_from_string(step.variable_value.mapping_value)
     = result.compact.join(", ").html_safe
   %td.border-left-0.border-right-0.border-bottom-0
@@ -28,13 +28,13 @@
             %th.border-0= t("dictionary")
             %th.border-0= t("dictionary_value")
             %th.border-0= t("updated_at")
-          - step_values.each do |step|
+          - step_values.order(:id).each do |step|
             %tr
               %td.border-0.w-15.break-all
                 = step.variable.name
               %td.border-0.w-15.break-all
                 %span{ data: { toggle: "tooltip" }, title: step.variable_value&.hint }
-                  = step.variable_value&.mapping_value
+                  = render_from_string step.variable_value&.mapping_value
               %td.border-0
                 %span.timeago{ "data-full-datetime": display_datetime(step.updated_at) }
                   = time_ago_in_words(step.updated_at)

--- a/spec/factories/variable.rb
+++ b/spec/factories/variable.rb
@@ -6,4 +6,33 @@ FactoryBot.define do
   trait :ticket_tracking do
     is_ticket_tracking { true }
   end
+
+  trait :gender do
+    name { 'gender' }
+    mark_as { 'gender' }
+    transient do
+      genders { ['female', 'male'] }
+    end
+
+    after(:create) do |variable, evaluator|
+      evaluator.genders.each do |gender|
+        create :variable_value, raw_value: gender, variable: variable
+      end
+    end
+  end
+
+  trait :location do
+    name { 'location' }
+    mark_as { 'location' }
+
+    transient do
+      locations { ['0204', '0212'] }
+    end
+
+    after(:create) do |variable, evaluator|
+      evaluator.locations.each do |location|
+        create :variable_value, raw_value: location, variable: variable
+      end
+    end
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -111,4 +111,21 @@ RSpec.describe Message do
       expect(message3.last_completed).to eq(message1)
     end
   end
+
+  describe "#clone" do
+    let!(:gender) { create(:variable, :gender) }
+    let!(:location) { create(:variable, :location) }
+
+    it "clones relations" do
+      old_message = create(:message, :text, district_id: '0204', gender: 'male')
+      old_message.completed!
+
+      new_message = create(:message, :text)
+      allow(new_message).to receive(:last_completed_before).and_return old_message
+
+      expect {
+        new_message.clone
+      }.to change { StepValue.count }
+    end
+  end
 end


### PR DESCRIPTION
## Issue description:
Before Message#clone, clones only attributes **:gender, :location**

## Solution:
Clone both **attributes and relations.**
So in this case, I will create 2 step_values by default for the cloned message, 
1. gender 
2. location