### PR TITLE
Static website  group report by monthly quarterly

### DIFF
--- a/app/assets/stylesheets/_welcome.scss
+++ b/app/assets/stylesheets/_welcome.scss
@@ -135,11 +135,13 @@
     color: #e41010;
   }
 
-  .period {
+  .access-period,
+  .track-period {
     border: 0;
     height: 25px;
     padding: 0;
     margin: 0;
+    background-color: transparent;
     @extend .h5 !optional;
     @extend .text-primary !optional;
   }

--- a/app/assets/stylesheets/_welcome.scss
+++ b/app/assets/stylesheets/_welcome.scss
@@ -135,6 +135,15 @@
     color: #e41010;
   }
 
+  .period {
+    border: 0;
+    height: 25px;
+    padding: 0;
+    margin: 0;
+    @extend .h5 !optional;
+    @extend .text-primary !optional;
+  }
+
   .social-share-button {
     margin-bottom: 30px;
     display: flex;

--- a/app/assets/stylesheets/_welcome.scss
+++ b/app/assets/stylesheets/_welcome.scss
@@ -137,13 +137,10 @@
 
   .access-period,
   .track-period {
-    border: 0;
-    height: 25px;
-    padding: 0;
-    margin: 0;
-    background-color: transparent;
-    @extend .h5 !optional;
-    @extend .text-primary !optional;
+    & + span .select2-selection.select2-selection--single {
+      height: 25px;
+      padding: 0 25px;
+    }
   }
 
   .social-share-button {

--- a/app/components/chart_component.html.haml
+++ b/app/components/chart_component.html.haml
@@ -2,11 +2,13 @@
   .card-header.py-3.d-flex.flex-row.align-items-center.justify-content-between
     .h5.m-0.font-weight-bold.text-primary
       = @name
-
+      = addon
     .tools
       = link_to "#", class: "chart-dl text-dark", data: { name: @name, toggle: "tooltip", title: t(:download_chart) } do
         %i.fa.fa-download
 
   .card-body
     .chart-wrapper.pt-4.d-flex.justify-content-around.align-items-center
+      - if @filterable
+        %i.fas.fa-sync.fa-spin.position-absolute.d-none
       = body

--- a/app/components/chart_component.html.haml
+++ b/app/components/chart_component.html.haml
@@ -1,7 +1,7 @@
 .card.shadow.mb-4{ role: "figure" }
   .card-header.py-3.d-flex.flex-row.align-items-center.justify-content-between
-    .h5.m-0.font-weight-bold.text-primary
-      = @name
+    .h5.m-0.font-weight-bold.text-primary.d-flex.justify-content-center.align-items-center
+      %span.d-inline-block.mr-3= @name
       = addon
     .tools
       = link_to "#", class: "chart-dl text-dark", data: { name: @name, toggle: "tooltip", title: t(:download_chart) } do
@@ -10,5 +10,6 @@
   .card-body
     .chart-wrapper.pt-4.d-flex.justify-content-around.align-items-center
       - if @filterable
-        %i.fas.fa-sync.fa-spin.position-absolute.d-none
+        %p.loading.position-absolute.d-none
+          = t("loading")
       = body

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -1,7 +1,8 @@
 class ChartComponent < ViewComponent::Base
-  with_content_areas :body
+  with_content_areas :addon, :body
 
-  def initialize(name: '')
+  def initialize(name: '', filterable: false)
     @name = name
+    @filterable = filterable
   end
 end

--- a/app/controllers/concerns/filterable.rb
+++ b/app/controllers/concerns/filterable.rb
@@ -12,7 +12,8 @@ module Filterable
       start_date: @start_date,
       end_date: @end_date,
       platform: params[:platform],
-      gender: params[:gender]
+      gender: params[:gender],
+      period: params[:period]
     }.with_indifferent_access
   end
 

--- a/app/controllers/welcomes_controller.rb
+++ b/app/controllers/welcomes_controller.rb
@@ -1,9 +1,9 @@
 class WelcomesController < PublicAccessController
   include Filterable
 
-  before_action :set_daterange, only: [:index, :q]
-  before_action :set_query, :set_gon, only: [:index, :q]
-  before_action :set_active_tab_nav, only: [:index, :q]
+  before_action :set_daterange, except: :filter
+  before_action :set_query, :set_gon, except: :filter
+  before_action :set_active_tab_nav, except: :filter
 
   def index
     respond_to do |format|
@@ -16,8 +16,12 @@ class WelcomesController < PublicAccessController
     render json: { display_name: @location_filter.display_name, district_list_name: @location_filter.district_list_name }
   end
 
-  def q
+  def access_info
     render json: @query.access_info, status: :ok
+  end
+
+  def service_tracked
+    render json: @query.most_tracked_periodic, status: :ok
   end
 
   private

--- a/app/controllers/welcomes_controller.rb
+++ b/app/controllers/welcomes_controller.rb
@@ -1,9 +1,9 @@
 class WelcomesController < PublicAccessController
   include Filterable
 
-  before_action :set_daterange, only: :index
-  before_action :set_query, :set_gon, only: :index
-  before_action :set_active_tab_nav, only: :index
+  before_action :set_daterange, only: [:index, :q]
+  before_action :set_query, :set_gon, only: [:index, :q]
+  before_action :set_active_tab_nav, only: [:index, :q]
 
   def index
     respond_to do |format|
@@ -14,6 +14,10 @@ class WelcomesController < PublicAccessController
 
   def filter
     render json: { display_name: @location_filter.display_name, district_list_name: @location_filter.district_list_name }
+  end
+
+  def q
+    render json: @query.access_info, status: :ok
   end
 
   private

--- a/app/javascript/charts/access_info_chart.js
+++ b/app/javascript/charts/access_info_chart.js
@@ -22,7 +22,7 @@ export const accessInfo = (collection = null) => {
 
   let data = extractData(collection || gon.accessInfo);
   let { scales } = defaults.initOptions
-  let max = _.max(data.datasets.data)
+  let max = _.max(data.datasets[0].data)
   let suggestedMax = Math.round( max * 1.2 )
 
   let options = {

--- a/app/javascript/charts/access_info_chart.js
+++ b/app/javascript/charts/access_info_chart.js
@@ -1,13 +1,10 @@
 import * as defaults from '../data/defaults'
 
-export const accessInfo = (collection = null) => {
-  let type = 'bar', 
-      plugins = [chartDataLabels];
-
-  let { colors, dataset } = collection || gon.accessInfo;
+export const extractData = (raw) => {
+  let { colors, dataset } = raw;
   let [monthLabels, values] = [_.keys(dataset), _.values(dataset)];
 
-  let data = {
+  return {
     labels: monthLabels,
     datasets: [
       {
@@ -17,9 +14,15 @@ export const accessInfo = (collection = null) => {
       }
     ]
   };
+}
 
+export const accessInfo = (collection = null) => {
+  let type = 'bar', 
+      plugins = [chartDataLabels];
+
+  let data = extractData(collection || gon.accessInfo);
   let { scales } = defaults.initOptions
-  let max = _.max(values)
+  let max = _.max(data.datasets.data)
   let suggestedMax = Math.round( max * 1.2 )
 
   let options = {

--- a/app/javascript/charts/access_info_chart.js
+++ b/app/javascript/charts/access_info_chart.js
@@ -1,10 +1,10 @@
 import * as defaults from '../data/defaults'
 
-export const accessInfo = () => {
+export const accessInfo = (collection = null) => {
   let type = 'bar', 
       plugins = [chartDataLabels];
 
-  let { colors, dataset } = gon.accessInfo;
+  let { colors, dataset } = collection || gon.accessInfo;
   let [monthLabels, values] = [_.keys(dataset), _.values(dataset)];
 
   let data = {

--- a/app/javascript/charts/most_tracked_periodic_chart.js
+++ b/app/javascript/charts/most_tracked_periodic_chart.js
@@ -1,10 +1,10 @@
 import * as defaults from '../data/defaults'
 
-export const mostTrackedPeriodic = () => {
+export const mostTrackedPeriodic = ( collection = null) => {
   let type = 'bar', 
       plugins = [chartDataLabels];
 
-  let { label, colors, dataset } = gon.mostTrackedPeriodic;
+  let { label, colors, dataset } = collection || gon.mostTrackedPeriodic;
   let [dataLabels, values] = [_.keys(dataset), _.values(dataset)];
   let titles = _.map(values, el => el.value);
   let counts = _.map(values, el => el.count);

--- a/app/javascript/charts/most_tracked_periodic_chart.js
+++ b/app/javascript/charts/most_tracked_periodic_chart.js
@@ -26,7 +26,7 @@ export const mostTrackedPeriodic = ( collection = null) => {
 
   let data = extractData(collection || gon.mostTrackedPeriodic);
   let { scales } = defaults.initOptions
-  let max = _.max(data.datasets.data)
+  let max = _.max(data.datasets[0].data)
   let suggestedMax = Math.round( max * 1.40 )
 
   let options = {

--- a/app/javascript/charts/most_tracked_periodic_chart.js
+++ b/app/javascript/charts/most_tracked_periodic_chart.js
@@ -1,15 +1,12 @@
 import * as defaults from '../data/defaults'
 
-export const mostTrackedPeriodic = ( collection = null) => {
-  let type = 'bar', 
-      plugins = [chartDataLabels];
-
-  let { label, colors, dataset } = collection || gon.mostTrackedPeriodic;
+export const extractData = (raw) => {
+  let { label, colors, dataset } = raw;
   let [dataLabels, values] = [_.keys(dataset), _.values(dataset)];
   let titles = _.map(values, el => el.value);
   let counts = _.map(values, el => el.count);
 
-  let data = {
+  return {
     labels: dataLabels,
     datasets: [
       {
@@ -21,9 +18,15 @@ export const mostTrackedPeriodic = ( collection = null) => {
       }
     ]
   };
+}
 
+export const mostTrackedPeriodic = ( collection = null) => {
+  let type = 'bar', 
+      plugins = [chartDataLabels];
+
+  let data = extractData(collection || gon.mostTrackedPeriodic);
   let { scales } = defaults.initOptions
-  let max = _.max(counts)
+  let max = _.max(data.datasets.data)
   let suggestedMax = Math.round( max * 1.40 )
 
   let options = {

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -52,7 +52,7 @@ OWSO.WelcomesIndex = (() => {
     let period = $(option.self).val()
     let serializedParams = $('#q').serialize()+`&period=${period}`
     let header = $(option.self).closest(".card-header");
-    let $spin = $(header.next().find(".fa-sync")[0]);
+    let $spin = $(header.next().find(".loading")[0]);
 
     loading($spin);
     let chart = findChartInstance(option.canvasId)
@@ -62,7 +62,6 @@ OWSO.WelcomesIndex = (() => {
       let max = _.max(chart.data.datasets[0].data);
       let suggestedMax = Math.round( max * 1.40 );
       chart.options.scales.yAxes[0].ticks.suggestedMax = suggestedMax;
-      console.log("scales: ", chart.options.scales, ", max: ", suggestedMax);
 
       chart.update();
 

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -26,26 +26,36 @@ OWSO.WelcomesIndex = (() => {
 
   function onChangePeriod() {
     $(document).on("change", ".access-period", function() {
-      fetchResultSet('/welcomes/q/access-info', this, accessInfo)
+      fetchResultSet('/welcomes/q/access-info', this, accessInfo, "chart_information_access_by_period")
     })
 
     $(document).on("change", ".track-period", function() {
-      fetchResultSet('/welcomes/q/service-tracked', this, mostTrackedPeriodic)
+      fetchResultSet('/welcomes/q/service-tracked', this, mostTrackedPeriodic, "chart_most_service_tracked_periodically")
     })
   }
 
-  function fetchResultSet(url, thiz, callback) {
+  function fetchResultSet(url, thiz, callback, canvasId) {
     let period = $(thiz).val()
     let serializedParams = $('#q').serialize()+`&period=${period}`
     let header = $(thiz).closest(".card-header");
     let $spin = $(header.next().find(".fa-sync")[0]);
 
     loading($spin);
+    // find chart instance
+    let chart = findChartInstance(canvasId)
+    chart.destroy()
+    // console.log(chart)
 
     $.get(url, serializedParams, function(result) {
       callback(result);
       loaded($spin);
     }, "json");
+  }
+
+  function findChartInstance(id) {
+    return _.find(Chart.instances, (instance) => {
+      return instance.chart.canvas.id == id
+    })
   }
 
   function loading(spin) {

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -59,6 +59,11 @@ OWSO.WelcomesIndex = (() => {
 
     $.get(option.url, serializedParams, function(result) {
       chart.data = option.extractor(result);
+      let max = _.max(chart.data.datasets[0].data);
+      let suggestedMax = Math.round( max * 1.40 );
+      chart.options.scales.yAxes[0].ticks.suggestedMax = suggestedMax;
+      console.log("scales: ", chart.options.scales, ", max: ", suggestedMax);
+
       chart.update();
 
       loaded($spin);

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -1,6 +1,7 @@
 require("../patches/jquery")
 import { renderChart } from '../charts/root_chart'
 import { accessInfo } from '../charts/access_info_chart';
+import { mostTrackedPeriodic } from '../charts/most_tracked_periodic_chart';
 
 OWSO.WelcomesIndex = (() => {
   let logoContainer, formQuery, pilotHeader;
@@ -24,20 +25,37 @@ OWSO.WelcomesIndex = (() => {
   }
 
   function onChangePeriod() {
-    $(document).on("change", ".period", function() {
-      let period = $(this).val();
-      let spin = $(".fa-sync");
-      let canvas = spin.next();
-      
-      spin.removeClass("d-none");
-      canvas.css({ opacity: 0.3 });
-
-      $.get('/welcomes/q', $('#q').serialize()+`&period=${period}`, function(result) {
-        accessInfo(result);
-        spin.addClass("d-none");
-        canvas.css({ opacity: 1 });
-      }, "json");
+    $(document).on("change", ".access-period", function() {
+      fetchResultSet('/welcomes/q/access-info', this, accessInfo)
     })
+
+    $(document).on("change", ".track-period", function() {
+      fetchResultSet('/welcomes/q/service-tracked', this, mostTrackedPeriodic)
+    })
+  }
+
+  function fetchResultSet(url, thiz, callback) {
+    let period = $(thiz).val()
+    let serializedParams = $('#q').serialize()+`&period=${period}`
+    let header = $(thiz).closest(".card-header");
+    let $spin = $(header.next().find(".fa-sync")[0]);
+
+    loading($spin);
+
+    $.get(url, serializedParams, function(result) {
+      callback(result);
+      loaded($spin);
+    }, "json");
+  }
+
+  function loading(spin) {
+    spin.removeClass("d-none");
+    spin.next().css({ opacity: 0.3 });
+  }
+
+  function loaded(spin) {
+    spin.addClass("d-none");
+    spin.next().css({ opacity: 1 });
   }
 
   function onClickTabNavigation() {

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -1,5 +1,6 @@
 require("../patches/jquery")
 import { renderChart } from '../charts/root_chart'
+import { accessInfo } from '../charts/access_info_chart';
 
 OWSO.WelcomesIndex = (() => {
   let logoContainer, formQuery, pilotHeader;
@@ -19,6 +20,24 @@ OWSO.WelcomesIndex = (() => {
     onChangeDistrict();
     onModalSave();
     onClickTabNavigation();
+    onChangePeriod(); 
+  }
+
+  function onChangePeriod() {
+    $(document).on("change", ".period", function() {
+      let period = $(this).val();
+      let spin = $(".fa-sync");
+      let canvas = spin.next();
+      
+      spin.removeClass("d-none");
+      canvas.css({ opacity: 0.3 });
+
+      $.get('/welcomes/q', $('#q').serialize()+`&period=${period}`, function(result) {
+        accessInfo(result);
+        spin.addClass("d-none");
+        canvas.css({ opacity: 1 });
+      }, "json");
+    })
   }
 
   function onClickTabNavigation() {

--- a/app/queries/access_info.rb
+++ b/app/queries/access_info.rb
@@ -19,7 +19,9 @@ class AccessInfo < Report
     end
 
     def raw_result
+      period = @query.options[:period].presence || :month
+
       Message.unscope(:order).accessed(@query.options).\
-        group_by_month(:created_at, format: "%b").count
+        group_by_period(period.to_sym, :created_at, format: "%d/%b").count
     end
 end

--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -38,7 +38,7 @@ class DashboardQuery
 
   def most_tracked_periodic
     most_request = Variable.most_request
-    result = ::MostTrackedPeriodic.new(most_request).result
+    result = ::MostTrackedPeriodic.new(most_request, self).result
     result.transform
   end
 

--- a/app/queries/most_tracked_periodic.rb
+++ b/app/queries/most_tracked_periodic.rb
@@ -29,8 +29,10 @@ class MostTrackedPeriodic < Report
   end
 
   def group_count
+    period = @query.options[:period].presence || :month
+
     Ticket.joins("INNER JOIN trackings ON trackings.ticket_code = tickets.code")\
-      .group_by_month("trackings.created_at", format: "%b")\
+      .group_by_period(period.to_sym, "trackings.created_at", format: "%d/%b")\
       .group(:sector)\
       .count
   end

--- a/app/views/welcomes/_form.haml
+++ b/app/views/welcomes/_form.haml
@@ -1,5 +1,5 @@
 #form-query
-  = simple_form_for :q, remote: true, method: :get, html: { class: "pt-3", role: "search" } do |f|
+  = simple_form_for :q, remote: true, method: :get, html: { class: "pt-3", id: "q", role: "search" } do |f|
     .mb-3
       .container
         .row

--- a/app/views/welcomes/_tabs.haml
+++ b/app/views/welcomes/_tabs.haml
@@ -24,8 +24,11 @@
               - c.with(:body) { content_tag(:canvas, nil, id: "chart_information_access_by_gender") }
 
           .col-xl-6.col-lg-5
-            - name = t("welcomes.information_access_by", period: t("period.month"))
-            = render( ChartComponent.new(name: name) ) do |c|
+            = render( ChartComponent.new(name: t("welcomes.information_access_by"), filterable: true) ) do |c|
+              - c.with(:addon) do
+                %select.form-control-sm.d-inline.period
+                  %option{ value: "month" }= t("period.month")
+                  %option{ value: "quarter" }= t("period.quarter")
               - c.with(:body) { content_tag(:canvas, nil, id: "chart_information_access_by_period") }
 
           .col-xl-6.col-lg-5

--- a/app/views/welcomes/_tabs.haml
+++ b/app/views/welcomes/_tabs.haml
@@ -26,7 +26,7 @@
           .col-xl-6.col-lg-5
             = render( ChartComponent.new(name: t("welcomes.information_access_by"), filterable: true) ) do |c|
               - c.with(:addon) do
-                %select.form-control-sm.d-inline.period
+                %select.form-control-sm.d-inline.access-period
                   %option{ value: "month" }= t("period.month")
                   %option{ value: "quarter" }= t("period.quarter")
               - c.with(:body) { content_tag(:canvas, nil, id: "chart_information_access_by_period") }
@@ -36,8 +36,12 @@
               - c.with(:body) { content_tag(:canvas, nil, id: "chart_number_access_by_main_services") }
 
           .col-xl-6.col-lg-5
-            - name = t("welcomes.most_service_tracked_by_periodic", period: 'month')
-            = render( ChartComponent.new(name: name) ) do |c|
+            - name = t("welcomes.most_service_tracked_by_periodic")
+            = render( ChartComponent.new(name: name, filterable: true) ) do |c|
+              - c.with(:addon) do
+                %select.form-control-sm.d-inline.track-period
+                  %option{ value: "month" }= t("period.month")
+                  %option{ value: "quarter" }= t("period.quarter")
               - c.with(:body) do
                 %canvas#chart_most_service_tracked_periodically
 

--- a/app/views/welcomes/_tabs.haml
+++ b/app/views/welcomes/_tabs.haml
@@ -26,7 +26,7 @@
           .col-xl-6.col-lg-5
             = render( ChartComponent.new(name: t("welcomes.information_access_by"), filterable: true) ) do |c|
               - c.with(:addon) do
-                %select.form-control-sm.d-inline.access-period
+                %select.access-period
                   %option{ value: "month" }= t("period.month")
                   %option{ value: "quarter" }= t("period.quarter")
               - c.with(:body) { content_tag(:canvas, nil, id: "chart_information_access_by_period") }
@@ -39,7 +39,7 @@
             - name = t("welcomes.most_service_tracked_by_periodic")
             = render( ChartComponent.new(name: name, filterable: true) ) do |c|
               - c.with(:addon) do
-                %select.form-control-sm.d-inline.track-period
+                %select.track-period
                   %option{ value: "month" }= t("period.month")
                   %option{ value: "quarter" }= t("period.quarter")
               - c.with(:body) do

--- a/app/views/welcomes/index.js.erb
+++ b/app/views/welcomes/index.js.erb
@@ -1,5 +1,7 @@
 window.gon = JSON.parse('<%= j(@gon_data.to_json.html_safe) %>');
-console.log("<%= j(@query.options.to_json.html_safe) %>");
+
 $(".tab-navigation").removeClass("d-none");
 $(".tabs-container").html("<%= j(render partial: "welcomes/tabs", locals: { active_tab: @active_tab }) %>");
+
 OWSO.WelcomesIndex.renderChart();
+OWSO.DashboardShow.multiSelectDistricts();

--- a/config/locales/datetime/en.yml
+++ b/config/locales/datetime/en.yml
@@ -1,6 +1,7 @@
 en:
   period:
     month: month
+    quarter: quarter
   date:
     abbr_month_names:
       - 

--- a/config/locales/datetime/km.yml
+++ b/config/locales/datetime/km.yml
@@ -1,6 +1,7 @@
 km:
   period:
     month: ខែ
+    quarter: ត្រីមាស
   date:
     abbr_month_names:
       - 

--- a/config/locales/welcomes/en.yml
+++ b/config/locales/welcomes/en.yml
@@ -12,7 +12,7 @@ en:
     information_access_by_gender: Information Access by Gender
     information_access_by: Information Access by
     number_access_by_main_services: Number Access by Main Service
-    most_service_tracked_by_periodic: Most Service Tracked by %{period}
+    most_service_tracked_by_periodic: Most Service Tracked by
     ticket_tracking_by_gender: Ticket Tracking by Gender
     overall_rating_by_owso: Overall Rating by OWSO
     owso_feedback_trend: OWSO Feedback Trend

--- a/config/locales/welcomes/en.yml
+++ b/config/locales/welcomes/en.yml
@@ -10,7 +10,7 @@ en:
     time_period: Time period
     most_requested_services: Most Requested Service by OWSO
     information_access_by_gender: Information Access by Gender
-    information_access_by: Information Access by %{period}
+    information_access_by: Information Access by
     number_access_by_main_services: Number Access by Main Service
     most_service_tracked_by_periodic: Most Service Tracked by %{period}
     ticket_tracking_by_gender: Ticket Tracking by Gender

--- a/config/locales/welcomes/km.yml
+++ b/config/locales/welcomes/km.yml
@@ -10,7 +10,7 @@ km:
     time_period: ពេលវេលា
     most_requested_services: សេវាកម្មដែលត្រូវបានស្នើសុំភាគច្រើនជាងគេ
     information_access_by_gender: ការទទួលបានព័ត៌មានដោយយេនឌ័រ
-    information_access_by: ការទទួលបានព័ត៌មានដោយ %{period}
+    information_access_by: ការទទួលបានព័ត៌មានតាម
     number_access_by_main_services: ការចូលប្រើលេខតាមរយៈសេវាកម្មមេ
     most_service_tracked_by_periodic: សេវាកម្មភាគច្រើនតាមដានដោយ %{period}
     ticket_tracking_by_gender: ការតាមដានសំបុត្រដោយភេទ

--- a/config/locales/welcomes/km.yml
+++ b/config/locales/welcomes/km.yml
@@ -12,7 +12,7 @@ km:
     information_access_by_gender: ការទទួលបានព័ត៌មានដោយយេនឌ័រ
     information_access_by: ការទទួលបានព័ត៌មានតាម
     number_access_by_main_services: ការចូលប្រើលេខតាមរយៈសេវាកម្មមេ
-    most_service_tracked_by_periodic: សេវាកម្មភាគច្រើនតាមដានដោយ %{period}
+    most_service_tracked_by_periodic: សេវាកម្មភាគច្រើនតាមដានតាម
     ticket_tracking_by_gender: ការតាមដានសំបុត្រដោយភេទ
     overall_rating_by_owso: ការវាយតម្លៃរួមដោយការិយាល័យច្រកចេញចូលតែមួយ
     owso_feedback_trend: មតិប្រតិកម្ម OWSO

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,8 @@ Rails.application.routes.draw do
     get :dashboard, to: "dashboard#show"
     get :home, to: "home#index"
     get "welcomes/filter"
-    get "welcomes/q"
+    get "welcomes/q/access-info", to: "welcomes#access_info"
+    get "welcomes/q/service-tracked", to: "welcomes#service_tracked"
 
     resources :users
     resources :tickets, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     get :dashboard, to: "dashboard#show"
     get :home, to: "home#index"
     get "welcomes/filter"
+    get "welcomes/q"
 
     resources :users
     resources :tickets, only: [:index]


### PR DESCRIPTION
1. Ability to view as monthly, quarterly for charts **information access** and **service tracked**
2. Fix consistent combobox
3. Fix consistent loading

for options `half-year`, `yearly` does not yet implement,
because there is an [open issue not yet solved](https://github.com/ankane/groupdate/pull/107)

![image](https://user-images.githubusercontent.com/5484758/102317210-bdb96980-3fa9-11eb-94f6-39c9ead327c0.png)
