### PR TITLE
Static website  quarterly incorrect xaxis label

### DIFF
--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -55,7 +55,7 @@ OWSO.WelcomesIndex = (() => {
     let $spin = $(header.next().find(".loading")[0]);
 
     loading($spin);
-    let chart = findChartInstance(option.canvasId)
+    chart = findChartInstance(option.canvasId)
 
     $.get(option.url, serializedParams, function(result) {
       chart.data = option.extractor(result);
@@ -70,9 +70,16 @@ OWSO.WelcomesIndex = (() => {
   }
 
   function findChartInstance(id) {
-    return _.find(Chart.instances, (instance) => {
-      return instance.chart.canvas.id == id
-    })
+    let chart
+
+    Chart.helpers.each(Chart.instances, function (instance) {
+      if (instance.chart.canvas.id === id) {
+        chart = instance;
+        return
+      }
+    });
+
+    return chart
   }
 
   function loading(spin) {

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -55,7 +55,7 @@ OWSO.WelcomesIndex = (() => {
     let $spin = $(header.next().find(".loading")[0]);
 
     loading($spin);
-    chart = findChartInstance(option.canvasId)
+    let chart = findChartInstance(option.canvasId)
 
     $.get(option.url, serializedParams, function(result) {
       chart.data = option.extractor(result);
@@ -73,10 +73,8 @@ OWSO.WelcomesIndex = (() => {
     let chart
 
     Chart.helpers.each(Chart.instances, function (instance) {
-      if (instance.chart.canvas.id === id) {
-        chart = instance;
-        return
-      }
+      let { canvas } = instance.chart
+      if (canvas.id === id) chart = instance; return
     });
 
     return chart


### PR DESCRIPTION
problem cause by find chart instance by _.find will return new copy of chart instance ,
therefore, cannot update (lost reference) chart data