### PR TITLE
Fix break layout districts subheading

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -6,4 +6,12 @@ module WelcomeHelper
   def district(district_id)
     Pumi::District.find_by_id(district_id)
   end
+
+  def show_location_detail
+    full_district_list_name ? @location_filter.display_name : I18n.t("dashboard.all_district")
+  end
+
+  def full_district_list_name
+    @location_filter.full_district_list_name.presence
+  end
 end

--- a/app/javascript/welcomes/index.js
+++ b/app/javascript/welcomes/index.js
@@ -143,6 +143,7 @@ OWSO.WelcomesIndex = (() => {
       } else {
         $("#show-districts").text(gon.all);
         $("#q_districts").val("");
+        $(".tooltip-district").attr("data-original-title", "");
       }
 
       $("#districtsModal").modal("hide");

--- a/app/views/welcomes/_tabs.haml
+++ b/app/views/welcomes/_tabs.haml
@@ -77,7 +77,9 @@
           .col-lg-6
             = render( ChartComponent.new(name: t("welcomes.feedback_by_sub_categories", name: @location_filter.province_name)) ) do |c|
               - c.with(:subheader) do
-                = "(#{ @location_filter.full_district_list_name.presence || I18n.t("dashboard.all_district") })"
+                %span{ data: { toggle: "tooltip", title: full_district_list_name } }
+                  = show_location_detail
+                &middot;
                 = link_to t("sites.view_detail"), "#", data: { toggle: "modal", target: "#popup", size: "modal-lg", title: t("sites.sub_category_detail", province: @location_filter.province_name(:short)), element: ".sub_categories", callback: "loadSubCategories" }
               - c.with(:body) { content_tag(:canvas, nil, id: "chart_feedback_by_sub_category") }
       

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,7 +170,7 @@ en:
     type_search: Type your search...
     district: District
     all_province: All
-    all_district: All
+    all_district: All Districts
     all: All
     location: Location
   reports:


### PR DESCRIPTION
## Move full district names to tooltip

![image](https://user-images.githubusercontent.com/5484758/105122597-1334e900-5b09-11eb-881e-f6585bb3305c.png)
