### PR TITLE
Fix charts province no districts flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "i18n-js", "~> 3.5.1"
 gem "liquid", "~> 4.0", ">= 4.0.3"
 gem "tilt", "~> 2.0", ">= 2.0.10"
 gem "sentry-raven", "~> 3.0"
-gem 'pumi', github: 'radinreth/pumi', require: 'pumi/rails'
+gem 'pumi', github: 'radinreth/pumi', branch: 'other-districts', require: 'pumi/rails'
 
 gem "telegram-bot", "~> 0.14.3"
 gem "sidekiq-scheduler", "~> 3.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,8 @@ GIT
 
 GIT
   remote: https://github.com/radinreth/pumi.git
-  revision: b9de5f38bdc95df66b13504b9e0d02da66a3e55c
+  revision: e66c8bb9434f1d56130dbda9a01d60d9410885ef
+  branch: other-districts
   specs:
     pumi (0.5.0)
 

--- a/app/javascript/charts/citizen-feedback/overall_rating_chart.js
+++ b/app/javascript/charts/citizen-feedback/overall_rating_chart.js
@@ -3,10 +3,11 @@ import { ticksOptions } from '../../utils/bar_chart'
 
 class OverallFeedbackChart extends GroupBarChart {
   chartId = 'chart_overall_rating_by_owso';
-  ticksOptions = ticksOptions
+  ticksOptions = {}
 
   format = () => {
     let { labels, dataset } = this.ds;
+    this.ticksOptions = (labels && labels.length > 4) ? ticksOptions : {}
 
     return { labels, datasets: _.map(dataset, (el) => el) };
   }

--- a/app/queries/overall_rating.rb
+++ b/app/queries/overall_rating.rb
@@ -13,7 +13,7 @@ class OverallRating < Feedback
         {
           label: named_status(status),
           backgroundColor: colors_mapping[status],
-          data: districts.keys.map { |district_name| districts[district_name][status] }
+          data: districts.keys.map { |district_name| districts[district_name][status].to_i }
         }
       end
     end


### PR DESCRIPTION
### Change Request
1. Overall rating chart: Show zero lable instead of null
2. Update pumi gem with other districts for each province
3. Overall rating: dynamic label rotate and truncate

### Migration
```ruby
date_introduce_new_location_flow = '2021/03/31'
Session.transaction do
    Session\
      .where(district_id: nil)\
      .where('date(created_at) > ?', date_introduce_new_location_flow)\
      .find_each do |session|
      other_district_id = "#{session.province_id}00"
      session.update!(district_id: other_district_id)

      # create district raw value if not exists
      district = Variable.district
      if district.present?
        value = district.values.find_or_initialize_by(raw_value: other_district_id)
        value.save! if value.new_record?
      end
    end
  end
```

### Image

![image](https://user-images.githubusercontent.com/5484758/113809512-7e01d200-9792-11eb-81a7-3c7e9c89b4fa.png)
