### PR TITLE
Enhance chart show full xaxes label

### DIFF
--- a/app/javascript/application/util.js
+++ b/app/javascript/application/util.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import { sum } from '../utils/array'
 
 OWSO.Util = {
@@ -17,6 +18,13 @@ OWSO.Util = {
     let thiz = this;
 
     Chart.plugins.register({
+      beforeInit: function (chart) {
+        chart.data.labels.forEach(function (label, index, labelsArr) {
+          if (/\s/.test(label) && thiz.preferMultilinesLabel(chart) ) {
+            labelsArr[index] = label.split(/\s/)
+          }
+        })
+      },
       afterDraw: function(chart) {
         let { datasets } = chart.data
 
@@ -36,6 +44,10 @@ OWSO.Util = {
         }
       }
     });
+  },
+
+  preferMultilinesLabel(chart) {
+    return (chart.config.type == 'bar' || chart.canvas.id == 'chart_number_access_by_main_services')
   },
 
   isEmpty(datasets) {

--- a/app/javascript/charts/citizen-feedback/feedback_trend_chart.js
+++ b/app/javascript/charts/citizen-feedback/feedback_trend_chart.js
@@ -1,13 +1,10 @@
 import GroupBarChart from '../group_bar_chart'
-import { ticksOptions } from '../../utils/bar_chart'
 
 class TrendingFeedbackChart extends GroupBarChart {
   chartId = 'chart_owso_feedback_trend';
-  ticksOptions = {}
 
   format = () => {
     let { labels, dataset } = gon.feedbackTrend;
-    this.ticksOptions = (labels && labels.length > 4) ? ticksOptions : {}
     return { labels, datasets: _.map(dataset, (el) => el) };
   }
 }

--- a/app/javascript/charts/citizen-feedback/overall_rating_chart.js
+++ b/app/javascript/charts/citizen-feedback/overall_rating_chart.js
@@ -1,13 +1,10 @@
 import GroupBarChart from '../group_bar_chart'
-import { ticksOptions } from '../../utils/bar_chart'
 
 class OverallFeedbackChart extends GroupBarChart {
   chartId = 'chart_overall_rating_by_owso';
-  ticksOptions = {}
 
   format = () => {
     let { labels, dataset } = this.ds;
-    this.ticksOptions = (labels && labels.length > 4) ? ticksOptions : {}
 
     return { labels, datasets: _.map(dataset, (el) => el) };
   }

--- a/app/javascript/charts/filtered_bar_chart.js
+++ b/app/javascript/charts/filtered_bar_chart.js
@@ -1,10 +1,8 @@
 import BarChart from './bar_chart'
 import { extract } from '../utils'
-import { ticksOptions } from '../utils/bar_chart';
 
 class FilteredBarChart extends BarChart {
   ancestor = new BarChart();
-  ticksOptions = ticksOptions
 
   dataTitles = (data) => _.map(data.values, el => el.value);
   dataCounts = (data) => _.map(data.values, el => el.count);

--- a/app/javascript/charts/owso-information-accessed/access_info_chart.js
+++ b/app/javascript/charts/owso-information-accessed/access_info_chart.js
@@ -1,9 +1,8 @@
 import BarChart from '../bar_chart'
-import { extractBarDataset, ticksOptions, suggestedMax } from '../../utils/bar_chart'
+import { extractBarDataset, suggestedMax } from '../../utils/bar_chart'
 
 class InformationAccessChart extends BarChart {
   chartId = 'chart_information_access_by_period';
-  ticksOptions = ticksOptions;
 
   suggestedMax = (data) => suggestedMax(data, 1.5);
   dataset = () => extractBarDataset(gon.accessInfo);

--- a/app/javascript/charts/scatter_chart.js
+++ b/app/javascript/charts/scatter_chart.js
@@ -21,14 +21,6 @@ class ScatterChart extends LineChart {
         xAxes:[{
           ticks: {
             autoSkip: false,
-            maxRotation: 45,
-            minRotation: 45,
-            callback: function(value) {
-              let maxLength = 10,
-                  ellipsisValue = `${value.substr(0, 10)}...`;
-          
-              return (value.length >= maxLength) ? ellipsisValue : value;
-            },
           }
         }],
         yAxes: [{

--- a/app/javascript/dashboard/show.js
+++ b/app/javascript/dashboard/show.js
@@ -2,9 +2,6 @@ import { subCategoriesFeedback } from '../charts/citizen-feedback/feedback_sub_c
 import { overallFeedback } from '../charts/citizen-feedback/overall_rating_chart'
 import { mostRequest } from '../charts/owso-information-accessed/most_request_service_access_chart'
 import formater from '../data/formater'
-import { ticksOptions } from '../utils/bar_chart';
-
-let MAX_LABELS_SIZE = 4;
 
 OWSO.DashboardShow = (() => {
 
@@ -90,8 +87,6 @@ OWSO.DashboardShow = (() => {
       let max = _.max(flatten(chart.data.datasets));
       let suggestedMax = Math.round( max * 1.40 );
       
-      let { labels } = extractor(result);
-      chart.options.scales.xAxes[0].ticks = (labels && labels.length > MAX_LABELS_SIZE) ? ticksOptions : {};
       chart.options.scales.yAxes[0].ticks.suggestedMax = suggestedMax;
 
       chart.update();

--- a/app/javascript/utils/bar_chart/index.js
+++ b/app/javascript/utils/bar_chart/index.js
@@ -19,13 +19,3 @@ export const extractBarDataset = (ds) => {
 export const suggestedMax = function ( array, scale = 1.2 ) {
   return _.max(array) * scale
 }
-
-export const ticksOptions = {
-  maxRotation: 45,
-  minRotation: 45,
-  callback: function(value) {
-    let maxLength = 10,
-        ellipsisValue = `${value.substr(0, 10)}...`;
-    return (value.length >= maxLength) ? ellipsisValue : value;
-  }
-}

--- a/app/queries/access_info.rb
+++ b/app/queries/access_info.rb
@@ -7,7 +7,7 @@ class AccessInfo < BasicReport
     def result_set
       scope = Session.unscope(:order)
       scope = scope.accessed(@query.options)
-      scope = scope.group_by_period(period, :created_at, format: "%b/%Y")
+      scope = scope.group_by_period(period, :created_at, format: "%b/%y")
       scope.count
     rescue
       {}

--- a/app/queries/access_info.rb
+++ b/app/queries/access_info.rb
@@ -7,7 +7,7 @@ class AccessInfo < BasicReport
     def result_set
       scope = Session.unscope(:order)
       scope = scope.accessed(@query.options)
-      scope = scope.group_by_period(period, :created_at, format: "%b/%y")
+      scope = scope.group_by_period(period, :created_at, format: "%b/%y,%Y")
       scope.count
     rescue
       {}

--- a/app/queries/chart_labels/month_label.rb
+++ b/app/queries/chart_labels/month_label.rb
@@ -5,7 +5,7 @@ module ChartLabels
     end
 
     def format
-      @raw
+      @raw.split(",")[0]
     end
   end
 end

--- a/app/queries/chart_labels/quarter_label.rb
+++ b/app/queries/chart_labels/quarter_label.rb
@@ -6,7 +6,8 @@ module ChartLabels
 
     def format
       q = Quarterly.new(@m)
-      I18n.t("chart.quarter_label", q: q.to_quarter, y: @y)
+      y = @y.split(",")[0]
+      I18n.t("chart.quarter_label", q: q.to_quarter, y: y)
     end
   end
 end

--- a/app/queries/chart_labels/year_label.rb
+++ b/app/queries/chart_labels/year_label.rb
@@ -5,7 +5,7 @@ module ChartLabels
     end
 
     def format
-      @raw.split("/")[1]
+      @raw.split(",")[1]
     end
   end
 end

--- a/app/queries/feedback_trend.rb
+++ b/app/queries/feedback_trend.rb
@@ -32,7 +32,7 @@ class FeedbackTrend < Feedback
       scope = StepValue.filter(@query.options, @variable.step_values)
       scope = scope.joins(:session)
       scope = scope.where(sessions: { province_id: @query.province_codes })
-      scope = scope.group_by_period(period, "sessions.created_at", format: "%b/%y")
+      scope = scope.group_by_period(period, "sessions.created_at", format: "%b/%y,%Y")
       scope = scope.group(:variable_value_id)
       scope.count
     end

--- a/app/queries/feedback_trend.rb
+++ b/app/queries/feedback_trend.rb
@@ -32,7 +32,7 @@ class FeedbackTrend < Feedback
       scope = StepValue.filter(@query.options, @variable.step_values)
       scope = scope.joins(:session)
       scope = scope.where(sessions: { province_id: @query.province_codes })
-      scope = scope.group_by_period(period, "sessions.created_at", format: "%b/%Y")
+      scope = scope.group_by_period(period, "sessions.created_at", format: "%b/%y")
       scope = scope.group(:variable_value_id)
       scope.count
     end

--- a/app/queries/most_tracked_periodic.rb
+++ b/app/queries/most_tracked_periodic.rb
@@ -21,7 +21,7 @@ class MostTrackedPeriodic < BasicReport
       scope = Ticket.filter(@query.options)
       scope = scope.joins(""" INNER JOIN trackings ON
                               trackings.ticket_code = tickets.code""")
-      scope = scope.group_by_period(period, "trackings.created_at", format: "%b/%Y")
+      scope = scope.group_by_period(period, "trackings.created_at", format: "%b/%y")
       scope = scope.group(:sector)
       scope.count
     end

--- a/app/queries/most_tracked_periodic.rb
+++ b/app/queries/most_tracked_periodic.rb
@@ -21,7 +21,7 @@ class MostTrackedPeriodic < BasicReport
       scope = Ticket.filter(@query.options)
       scope = scope.joins(""" INNER JOIN trackings ON
                               trackings.ticket_code = tickets.code""")
-      scope = scope.group_by_period(period, "trackings.created_at", format: "%b/%y")
+      scope = scope.group_by_period(period, "trackings.created_at", format: "%b/%y,%Y")
       scope = scope.group(:sector)
       scope.count
     end


### PR DESCRIPTION
### Change Request

1. Show multi-lines x-axe label instead of rotated and truncated

#### Before
![image](https://user-images.githubusercontent.com/5484758/116181130-460ffe00-a744-11eb-8da1-01090ed66402.png)

#### After
![image](https://user-images.githubusercontent.com/5484758/116181192-693aad80-a744-11eb-8e8f-6cb86dd44433.png)


2. Enhance filterable chart : show only 2 digit years (save space) when filter `:month` and `:quarter`, for `:year` show 4 digits 

#### Before
![image](https://user-images.githubusercontent.com/5484758/116181673-3c3aca80-a745-11eb-8245-0f3dd068441b.png)

#### After
![image](https://user-images.githubusercontent.com/5484758/116181735-54aae500-a745-11eb-8901-df5be6a0c2db.png)