### PR TITLE
Enhance session updated at

### DIFF
--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -101,6 +101,6 @@ class DictionariesController < ApplicationController
     end
 
     def variable_params
-      params.require(:variable).permit(:type, :name, :mark_as, role_ids: [], values_attributes: [:id, :raw_value, :mapping_value_en, :mapping_value_km, :hint, :status, :_destroy])
+      params.require(:variable).permit(:type, :name, :mark_as, role_ids: [], values_attributes: [:id, :raw_value, :mapping_value_en, :mapping_value_km, :hint, :value_status, :_destroy])
     end
 end

--- a/app/javascript/charts/owso-information-accessed/ticket_tracking_by_genders_chart.js
+++ b/app/javascript/charts/owso-information-accessed/ticket_tracking_by_genders_chart.js
@@ -1,8 +1,8 @@
-import DonutChart from '../donut_chart'
-import { extractDonutDataset } from '../../utils/donut_chart'
+import DonutChart from "../donut_chart";
+import { extractDonutDataset } from "../../utils/donut_chart";
 
 class TicketTrackingAccessChart extends DonutChart {
-  chartId = 'chart_ticket_tracking_by_gender';
+  chartId = "chart_ticket_tracking_by_gender";
 
   suggestedMax = (data) => suggestedMax(data, 1.5);
   dataset = () => extractDonutDataset(gon.ticketTrackingByGenders);

--- a/app/models/concerns/session/filterable_concern.rb
+++ b/app/models/concerns/session/filterable_concern.rb
@@ -11,7 +11,7 @@ module Session::FilterableConcern
       scope = scope.where("province_id IN (?) ", ProvinceFilter.fetch(params[:province_id])) if params[:province_id].present?
       scope = scope.where("district_id IN (?) ", DistrictFilter.fetch(params[:district_id])) if params[:district_id].present?
       scope = scope.where(platform_name: params[:platform]) if params[:platform].present?
-      scope = scope.where("DATE(sessions.created_at) BETWEEN ? AND ?", params[:start_date], params[:end_date]) if params[:start_date].present? && params[:end_date].present?
+      scope = scope.where("DATE(sessions.engaged_at) BETWEEN ? AND ?", params[:start_date], params[:end_date]) if params[:start_date].present? && params[:end_date].present?
       scope
     end
   end

--- a/app/models/concerns/step_value/aggregatable_concern.rb
+++ b/app/models/concerns/step_value/aggregatable_concern.rb
@@ -14,13 +14,6 @@ module StepValue::AggregatableConcern
       default.merge(result).transform_keys { |k| I18n.t(k.downcase.to_sym) }
     end
 
-    def self.users_visited_by_each_genders(params = {})
-      params = params.merge(variable_value: VariableValue.kind_of_criteria)
-      
-      scope = joins(:session).where.not(sessions: { gender: '' })
-      scope = filter(params, scope)
-    end
-
     def self.total_users_visit(variable, params = {})
       key = "mapping_value_#{ I18n.locale }".to_sym
       

--- a/app/models/concerns/step_value/aggregatable_concern.rb
+++ b/app/models/concerns/step_value/aggregatable_concern.rb
@@ -5,9 +5,9 @@ module StepValue::AggregatableConcern
     def self.total_users_feedback(variable, params = {})
       scope = filter(params.merge(variable_id: variable))
 
-      statuses = VariableValue.statuses
+      statuses = VariableValue.value_statuses
       default = statuses.transform_values { 0 }
-      result = scope.joins(:variable_value).group(:status).count.map do |k, v|
+      result = scope.joins(:variable_value).group(:value_status).count.map do |k, v|
         [statuses.key(k), v]
       end.to_h
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -36,6 +36,8 @@ class Session < ApplicationRecord
                               in: %w(Messenger Telegram Verboice),
                               message: I18n.t("sessions.invalid_platform_name", value: "%{value}") }
 
+  scope :with_genders, -> { where.not(gender: [nil, "", "null"]) }
+
   after_create_commit :completed!, if: :ivr?
 
   def self.create_or_return(platform_name, session_id)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -85,11 +85,12 @@ class Session < ApplicationRecord
     platform_name == "Verboice"
   end
 
-  def self.accessed(options = {})
-    variable = Variable.find_by(is_service_accessed: true)
-
+  def self.accessed(period=:day, format="%b/%y,%Y", options={})
     scope = filter(options)
-    scope.where(step_values: variable.step_values) if variable.present?
+    scope = scope.joins(:step_values)
+    scope = scope.where(step_values: { variable: Variable.service_accessed })
+    scope = scope.group_by_period(period, :created_at, format: format)
+    scope.count
   end
 
   def reachable_period?

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -3,6 +3,7 @@
 # Table name: sessions
 #
 #  id                  :bigint(8)        not null, primary key
+#  engaged_at          :datetime
 #  gender              :string           default("")
 #  last_interaction_at :datetime
 #  platform_name       :string           default("")

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -31,8 +31,6 @@ class Session < ApplicationRecord
   has_many :step_values, dependent: :destroy
   has_many :trackings, dependent: :destroy
 
-  default_scope -> { order(updated_at: :desc) }
-
   validates :session_id, :source_id, presence: true
   validates :platform_name, inclusion: {
                               in: %w(Messenger Telegram Verboice),

--- a/app/models/step_value.rb
+++ b/app/models/step_value.rb
@@ -50,6 +50,7 @@ class StepValue < ApplicationRecord
   after_commit :set_session_province_id,  on: [:create, :update],
                                           if: -> { variable_value.province? }
   after_commit :set_session_gender, on: [:create, :update], if: -> { variable.gender? }
+  after_save :engage_session
 
   scope :most_recent, -> { select("DISTINCT ON (variable_id) variable_id, variable_value_id, id").order("variable_id, updated_at DESC") }
 
@@ -107,5 +108,9 @@ class StepValue < ApplicationRecord
       rescue => e
         Rails.logger.info("#{e.message} for #{variable_value.raw_value}")
       end
+    end
+
+    def engage_session
+      session.touch(:engaged_at) if session.present?
     end
 end

--- a/app/models/step_value.rb
+++ b/app/models/step_value.rb
@@ -67,18 +67,6 @@ class StepValue < ApplicationRecord
     joins(:variable_value).where("variable_values.id in (?)", disatisfied.ids)
   end
 
-  def self.total_users_visit_each_functions(params = {})
-    key = "mapping_value_#{ I18n.locale }".to_sym
-
-    scope = all
-    scope = scope.joins(variable_value: :variable)
-    scope = filter(scope, params)
-    scope = scope.where(variable_id: Variable.user_visit)
-    scope = scope.order(key)
-    scope = scope.group(key)
-    scope.count
-  end
-
   def self.clone_step(attr, value)
     variable = Variable.send(attr)
     variable_value = variable.values.find_or_create_by(raw_value: value)

--- a/app/models/total_most_request_service_usage.rb
+++ b/app/models/total_most_request_service_usage.rb
@@ -17,14 +17,11 @@ class TotalMostRequestServiceUsage
   end
 
   def self.query
-    StepValue.filter(@options.merge(variable_options))\
-              .joins(:session)\
-              .group(:province_id, :variable_value_id)\
-              .order(:province_id, count_all: :desc)\
-              .count
-  end
-
-  def self.variable_options
-    { variable_id: Variable.most_request&.id }
+    Session.filter(@options)
+            .joins(:step_values)
+            .where(step_values: { variable: Variable.most_request })
+            .group(:province_id, :variable_value_id)
+            .order(:province_id, count_all: :desc)
+            .count
   end
 end

--- a/app/models/total_service_delivered_usage.rb
+++ b/app/models/total_service_delivered_usage.rb
@@ -1,18 +1,9 @@
 class TotalServiceDeliveredUsage
   def self.fetch(options)
-    @options = options
-    StepValue.filter(delivered_options, delivered_scope)\
-              .group(:province_id)\
-              .count
-  end
-
-  private
-
-  def self.delivered_options
-    @options.merge({ variable_id: Variable.user_visit&.id })
-  end
-
-  def self.delivered_scope
-    StepValue.joins(:session, variable_value: :variable)
+    Session.filter(options)
+            .joins(:step_values)
+            .where(step_values: { variable: Variable.user_visit })
+            .group(:province_id)
+            .count
   end
 end

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -69,7 +69,12 @@ class Variable < ApplicationRecord
   end
 
   def agg_value_count(options)
-    StepValue.agg_value_count(self, options)
+    Session.filter(options)
+            .joins(:step_values)
+            .where(step_values: { variable: self })
+            .order("count_all DESC")
+            .group(:variable_value_id)
+            .count
   end
 
   def criteria?

--- a/app/models/variable_value.rb
+++ b/app/models/variable_value.rb
@@ -8,9 +8,9 @@
 #  mapping_value_en  :string           default("")
 #  mapping_value_km  :string           default("")
 #  raw_value         :string           not null
-#  status            :string           default("acceptable")
 #  step_values_count :integer(4)       default(0)
 #  type_of           :string           default("")
+#  value_status      :string           default("1")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  variable_id       :bigint(8)        not null
@@ -24,7 +24,7 @@
 #  fk_rails_...  (variable_id => variables.id)
 #
 class VariableValue < ApplicationRecord
-  enum status: { like: "0", acceptable: "1", dislike: "2" }
+  enum value_status: { like: "0", acceptable: "1", dislike: "2" }
   USER_FEEDBACK = 'user_feedback'
 
   # associations

--- a/app/models/variable_value.rb
+++ b/app/models/variable_value.rb
@@ -10,7 +10,7 @@
 #  raw_value         :string           not null
 #  step_values_count :integer(4)       default(0)
 #  type_of           :string           default("")
-#  value_status      :string           default("1")
+#  value_status      :string           default("acceptable")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  variable_id       :bigint(8)        not null

--- a/app/queries/access_info.rb
+++ b/app/queries/access_info.rb
@@ -5,11 +5,6 @@ class AccessInfo < BasicReport
 
   private
     def result_set
-      scope = Session.unscope(:order)
-      scope = scope.accessed(@query.options)
-      scope = scope.group_by_period(period, :created_at, format: "%b/%y,%Y")
-      scope.count
-    rescue
-      {}
+      Session.accessed(period, '%b/%y,%Y', @query.options)
     end
 end

--- a/app/queries/access_main_service.rb
+++ b/app/queries/access_main_service.rb
@@ -10,10 +10,11 @@ class AccessMainService < BasicReport
   
   private
     def result_set
-      scope = StepValue.filter(@query.options, @variable.step_values)
-      scope = scope.joins(:session)
-      scope = scope.where(sessions: { province_id: @query.province_codes })
-      scope = scope.group("variable_value_id")
-      scope.count
+      Session.filter(@query.options)\
+              .joins(:step_values)\
+              .where(step_values: { variable: @variable })\
+              .where(province_id: @query.province_codes)\
+              .group(:variable_value_id)\
+              .count
     end
 end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -50,9 +50,9 @@ module Chart::ReportHelper
     ::UserByGender.new(nil, self).chart_options
   end
 
+  # OWSO Information Accessed > Ticket Tracking(Times)
   def ticket_tracking
-    ticket_tracking_report = ::TicketTracking.new(nil, self)
-    ticket_tracking_report.chart_options
+    ::TicketTracking.new(nil, self).chart_options
   end
 
   # Summary > Total User Feedback

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -58,6 +58,7 @@ module Chart::ReportHelper
     users_feedback_report.chart_options
   end
 
+  # Citizen Feedback > Feedback By Sub Categories
   def feedback_sub_categories
     categories_all.merge(categories_separate)
   end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -45,6 +45,7 @@ module Chart::ReportHelper
     ::UserVisitEachFunction.new(nil, self).chart_options
   end
 
+  # OWSO Information Accessed > Information Access By Gender
   def users_by_genders
     ::UserByGender.new(nil, self).chart_options
   end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -24,6 +24,7 @@ module Chart::ReportHelper
     ::MostTrackedPeriodic.new(nil, self).chart_options
   end
 
+  # OWSO Information Accessed > Ticket Tracking by Gender
   def ticket_tracking_by_genders
     ::TicketTrackingByGenders.new(nil, self).chart_options
   end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -8,6 +8,7 @@ module Chart::ReportHelper
     ::GenderInfo.new(nil, self).chart_options
   end
 
+  # OWSO Information Accessed > Information Access By :period
   def access_info
     ::AccessInfo.new(nil, self).chart_options
   end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -1,10 +1,7 @@
 module Chart::ReportHelper
+  # OWSO Information Accessed > Most Requested Service By OWSO
   def most_requested_services
-    most_request = Variable.most_request
-    most_requested_report = ::MostRequest.new(most_request, self)
-    most_requested_report.chart_options
-  rescue
-    {}
+    ::MostRequest.new(Variable.most_request, self).chart_options
   end
 
   def gender_info

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -18,6 +18,7 @@ module Chart::ReportHelper
     ::AccessMainService.new(Variable.service_accessed, self).chart_options
   end
 
+  # OWSO Information Accessed > Most Popular By :period (Not related to session)
   def most_tracked_periodic
     ::MostTrackedPeriodic.new(nil, self).chart_options
   end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -4,6 +4,7 @@ module Chart::ReportHelper
     ::MostRequest.new(Variable.most_request, self).chart_options
   end
 
+  # Citizen feedback > Total Feedback By Gender
   def gender_info
     ::GenderInfo.new(nil, self).chart_options
   end

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -59,8 +59,6 @@ module Chart::ReportHelper
 
   def feedback_sub_categories
     categories_all.merge(categories_separate)
-  rescue
-    {}
   end
 
   private

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -13,11 +13,9 @@ module Chart::ReportHelper
     ::AccessInfo.new(nil, self).chart_options
   end
 
+  # OWSO Information Accessed > Most Popular Service Information Requested By OWSO (scatter chart)
   def access_main_service
-    main_service = Variable.service_accessed
-    ::AccessMainService.new(main_service, self).chart_options
-  rescue
-    {}
+    ::AccessMainService.new(Variable.service_accessed, self).chart_options
   end
 
   def most_tracked_periodic

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -57,6 +57,7 @@ module Chart::ReportHelper
     ticket_tracking_report.chart_options
   end
 
+  # Summary > Total User Feedback
   def users_feedback
     users_feedback_report = ::UserFeedback.new(nil, self)
     users_feedback_report.chart_options

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -28,11 +28,9 @@ module Chart::ReportHelper
     ::TicketTrackingByGenders.new(nil, self).chart_options
   end
 
+  # Citizen Feedback > :pro_code > Overall Rating by OWSO
   def overall_rating
-    feedback = Variable.feedback
-    ::OverallRating.new(feedback, self).chart_options
-  rescue
-    {}
+    ::OverallRating.new(Variable.feedback, self).chart_options
   end
 
   def feedback_trend

--- a/app/queries/chart/report_helper.rb
+++ b/app/queries/chart/report_helper.rb
@@ -36,10 +36,7 @@ module Chart::ReportHelper
   end
 
   def feedback_trend
-    feedback = Variable.feedback
-    ::FeedbackTrend.new(feedback, self).chart_options
-  rescue
-    {}
+    ::FeedbackTrend.new(Variable.feedback, self).chart_options
   end
 
   def total_users_visit_by_category

--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -24,6 +24,7 @@ class DashboardQuery
     sessions.select("DISTINCT ON (session_id) *").reorder(:session_id, :gender)
   end
 
+  # Summary > Total Service Delivered
   def user_accessed_count
     total_users_visit_each_functions.values.sum
   end

--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -117,6 +117,7 @@ class DashboardQuery
     Variable.most_request.agg_value_count(@options).values.sum
   end
 
+  # OWSO Information Accessed > User Access
   def goals
     user_access = ::UserAccess.new nil, self
     user_access.chart_options[:dataset]

--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -81,11 +81,7 @@ class DashboardQuery
     end
   end
 
-  def ticket_tracking
-    ticket_tracking_report = ::TicketTracking.new(nil, self)
-    ticket_tracking_report.chart_options
-  end
-
+  # OWSO Information Accessed > Ticket Tracking(times)
   def number_of_tracking_tickets
     result = Tracking.filter(@options).group(:status).count
 

--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -56,14 +56,13 @@ class DashboardQuery
             .count
   end
 
-  def users_by_genders
-    users_gender_report = ::UserByGender.new(nil, self)
-    users_gender_report.chart_options
-  end
-
   def users_visited_by_each_genders
-    result = StepValue.users_visited_by_each_genders(@options)
-    result = result.group(:gender).count
+    result = Session.filter(@options)\
+              .joins(:step_values)\
+              .where(step_values: { variable_value: VariableValue.kind_of_criteria })\
+              .where.not(gender: '')\
+              .group(:gender)\
+              .count
 
     return {} if Variable.gender.nil?
 

--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -47,6 +47,7 @@ class DashboardQuery
     Session.filter(@options)
   end
 
+  # Summary > Total Visits By Type Of Service
   def total_users_visit_each_functions
     Session.filter(@options)\
             .joins(step_values: [:variable, :variable_value])\
@@ -98,11 +99,6 @@ class DashboardQuery
     return [] if variable.nil?
 
     StepValue.total_users_feedback(variable, @options)
-  end
-
-  def users_feedback
-    users_feedback_report = ::UserFeedback.new(nil, self)
-    users_feedback_report.chart_options
   end
 
   def total_users_feedback_by_gender

--- a/app/queries/feedback_report.rb
+++ b/app/queries/feedback_report.rb
@@ -1,9 +1,10 @@
 class FeedbackReport < GenericReport
   def sql
-    scope = StepValue.filter(@query.options, StepValue.joins(:session))
-    scope = scope.where(sessions: { province_id: @query.province_codes })
-    scope = scope.where(variable: [like, dislike])
-    scope = scope.group(:variable_id, :variable_value_id)
+    Session.filter(@query.options)\
+            .joins(:step_values)\
+            .where(step_values: { variable: [like, dislike] })\
+            .where(province_id: @query.province_codes)\
+            .group(:variable_id, :variable_value_id)
   end
 
   def colors

--- a/app/queries/feedback_sub_categories.rb
+++ b/app/queries/feedback_sub_categories.rb
@@ -21,7 +21,7 @@ class FeedbackSubCategories < FeedbackReport
     end
 
     def result_set
-      scope = sql.group("sessions.province_id")
+      scope = sql.group(:province_id)
       scope.count
     end
 end

--- a/app/queries/feedback_sub_category_item.rb
+++ b/app/queries/feedback_sub_category_item.rb
@@ -10,8 +10,8 @@ class FeedbackSubCategoryItem < FeedbackSubCategories
   private
 
     def result_set
-      scope = sql.where(sessions: { district_id: @query.district_codes })
-      scope = scope.group("sessions.district_id")
+      scope = sql.where(district_id: @query.district_codes)
+      scope = scope.group(:district_id)
       scope.count
     end
 end

--- a/app/queries/feedback_trend.rb
+++ b/app/queries/feedback_trend.rb
@@ -29,11 +29,12 @@ class FeedbackTrend < Feedback
     end
 
     def result_set
-      scope = StepValue.filter(@query.options, @variable.step_values)
-      scope = scope.joins(:session)
-      scope = scope.where(sessions: { province_id: @query.province_codes })
-      scope = scope.group_by_period(period, "sessions.created_at", format: "%b/%y,%Y")
-      scope = scope.group(:variable_value_id)
-      scope.count
+      Session.filter(@query.options)\
+              .joins(:step_values)\
+              .where(step_values: { variable: @variable })\
+              .where(province_id: @query.province_codes)\
+              .group_by_period(period, :created_at, format: '%b/%y,%Y')\
+              .group(:variable_value_id)\
+              .count
     end
 end

--- a/app/queries/gender_info.rb
+++ b/app/queries/gender_info.rb
@@ -11,10 +11,10 @@ class GenderInfo < BasicReport
   end
 
   def sql
-    scope = StepValue.filter(@query.options)
-    scope = scope.where(variable_value: VariableValue.type_of_user_feedback)
-    scope = scope.joins(:session)
-    scope = scope.group(:gender)
-    scope.count
+    Session.filter(@query.options)\
+            .joins(:step_values)\
+            .where(step_values: { variable_value: VariableValue.type_of_user_feedback })\
+            .group(:gender)\
+            .count
   end
 end

--- a/app/queries/most_request.rb
+++ b/app/queries/most_request.rb
@@ -22,13 +22,11 @@ class MostRequest < BasicReport
   end
 
   def result_set
-    scope = StepValue.filter(@query.options, @variable.step_values)
-    scope = scope.joins(:session)
-    scope = scope.where(sessions: { province_id: @query.province_codes })
-    scope = scope.group("sessions.province_id")
-    scope = scope.group("sessions.district_id")
-    scope = scope.group(:variable_value_id)
-    scope = scope.count
-    scope
+    Session.filter(@query.options)\
+            .joins(:step_values)\
+            .where(province_id: @query.province_codes )\
+            .where(step_values: @variable.step_values)\
+            .group(:province_id, :district_id, :variable_value_id)\
+            .count
   end
 end

--- a/app/queries/most_request.rb
+++ b/app/queries/most_request.rb
@@ -25,7 +25,7 @@ class MostRequest < BasicReport
     Session.filter(@query.options)\
             .joins(:step_values)\
             .where(province_id: @query.province_codes )\
-            .where(step_values: @variable.step_values)\
+            .where(step_values: { variable: @variable })\
             .group(:province_id, :district_id, :variable_value_id)\
             .count
   end

--- a/app/queries/ticket_tracking_by_genders.rb
+++ b/app/queries/ticket_tracking_by_genders.rb
@@ -12,10 +12,10 @@ class TicketTrackingByGenders < BasicReport
   
   private
     def result_set
-      scope = Session.filter(@query.options).unscope(:order)
-      scope = scope.where.not(gender: ["", "null"])
-      scope = scope.joins(:trackings)
-      scope = scope.group(:gender)
-      scope.count
+      Session.filter(@query.options)\
+            .with_genders\
+            .joins(:trackings)\
+            .group(:gender)\
+            .count
     end
 end

--- a/app/queries/user_access.rb
+++ b/app/queries/user_access.rb
@@ -11,7 +11,7 @@ class UserAccess < BasicReport
     # TODO: move site code to setting
     # mark_as: service_accessed( variable = owso_info )
     def accessed
-      data = Session.unscope(:order).accessed(@query.options).group_by_day(:created_at, format: "%b %e, %y").count
+      data = Session.accessed("%b %e, %y", @query.options)
       format(name: I18n.t("dashboard.accessed"), data: data)
     rescue
       nil

--- a/app/queries/user_access.rb
+++ b/app/queries/user_access.rb
@@ -8,13 +8,10 @@ class UserAccess < BasicReport
 
   private
 
-    # TODO: move site code to setting
     # mark_as: service_accessed( variable = owso_info )
     def accessed
-      data = Session.accessed("%b %e, %y", @query.options)
+      data = Session.accessed(:day, "%b %e, %y", @query.options)
       format(name: I18n.t("dashboard.accessed"), data: data)
-    rescue
-      nil
     end
 
     def submitted_from_synced_locations

--- a/app/queries/user_feedback.rb
+++ b/app/queries/user_feedback.rb
@@ -1,7 +1,16 @@
 class UserFeedback < Report
   def dataset
-    hash = StepValue.total_users_feedback(Variable.feedback, @query.options)
-    hash.transform_keys { |k| "#{icon_map[k]} #{k}" }
+    raw = Session.filter(@query.options)\
+            .joins(step_values: [:variable, :variable_value])\
+            .where(step_values: { variable: Variable.feedback })\
+            .group('variable_values.value_status')\
+            .count('sessions.id')
+
+    raw.transform_keys do |k|
+      k = VariableValue.value_statuses.key(k)
+      i18n = I18n.t(k)
+      "#{icon_map[i18n]} #{i18n}"
+    end
   end
 
   def colors

--- a/app/views/dictionaries/_value_fields.html.haml
+++ b/app/views/dictionaries/_value_fields.html.haml
@@ -19,9 +19,9 @@
           %td 😊
           %td 😞
         %tr
-          %td= f.radio_button :status, 0, checked: f.object.like?
-          %td= f.radio_button :status, 1, checked: f.object.acceptable?
-          %td= f.radio_button :status, 2, checked: f.object.dislike?
+          %td= f.radio_button :value_status, 0, checked: f.object.like?
+          %td= f.radio_button :value_status, 1, checked: f.object.acceptable?
+          %td= f.radio_button :value_status, 2, checked: f.object.dislike?
 
   %td.text-right
     - if f.object.destroyable?

--- a/config/locales/dictionaries/en.yml
+++ b/config/locales/dictionaries/en.yml
@@ -32,3 +32,4 @@ en:
     province: Province
     district: District
     feedback_dislike: Feedback dislike
+    feedback_like: Feedback like

--- a/config/locales/dictionaries/km.yml
+++ b/config/locales/dictionaries/km.yml
@@ -32,3 +32,4 @@ km:
     province: ខេត្ត
     district: ស្រុក
     feedback_dislike: មតិមិនចូលចិត្ត
+    feedback_like: មតិចូលចិត្ត

--- a/db/migrate/20210728091824_rename_status_to_variable_values.rb
+++ b/db/migrate/20210728091824_rename_status_to_variable_values.rb
@@ -1,0 +1,5 @@
+class RenameStatusToVariableValues < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :variable_values, :status, :value_status
+  end
+end

--- a/db/migrate/20210729091739_add_engaged_at_to_sessions.rb
+++ b/db/migrate/20210729091739_add_engaged_at_to_sessions.rb
@@ -1,6 +1,10 @@
 class AddEngagedAtToSessions < ActiveRecord::Migration[6.0]
-  def change
+  def up
     add_column :sessions, :engaged_at, :datetime, default: -> { "CURRENT_TIMESTAMP" }
     Rake::Task["session:migrate_engaged_at"].invoke
+  end
+
+  def down
+    remove_column :sessions, :engaged_at
   end
 end

--- a/db/migrate/20210729091739_add_engaged_at_to_sessions.rb
+++ b/db/migrate/20210729091739_add_engaged_at_to_sessions.rb
@@ -1,0 +1,6 @@
+class AddEngagedAtToSessions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :sessions, :engaged_at, :datetime, default: -> { "CURRENT_TIMESTAMP" }
+    Rake::Task["session:migrate_engaged_at"].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,48 +37,6 @@ ActiveRecord::Schema.define(version: 2021_07_29_091739) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "ahoy_events", force: :cascade do |t|
-    t.bigint "visit_id"
-    t.bigint "user_id"
-    t.string "name"
-    t.jsonb "properties"
-    t.datetime "time"
-    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
-    t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
-    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
-    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
-  end
-
-  create_table "ahoy_visits", force: :cascade do |t|
-    t.string "visit_token"
-    t.string "visitor_token"
-    t.bigint "user_id"
-    t.string "ip"
-    t.text "user_agent"
-    t.text "referrer"
-    t.string "referring_domain"
-    t.text "landing_page"
-    t.string "browser"
-    t.string "os"
-    t.string "device_type"
-    t.string "country"
-    t.string "region"
-    t.string "city"
-    t.float "latitude"
-    t.float "longitude"
-    t.string "utm_source"
-    t.string "utm_medium"
-    t.string "utm_term"
-    t.string "utm_content"
-    t.string "utm_campaign"
-    t.string "app_version"
-    t.string "os_version"
-    t.string "platform"
-    t.datetime "started_at"
-    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
-    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
-  end
-
   create_table "identities", force: :cascade do |t|
     t.string "provider"
     t.string "token"
@@ -203,12 +161,6 @@ ActiveRecord::Schema.define(version: 2021_07_29_091739) do
     t.string "name_km"
     t.index ["deleted_at"], name: "index_sites_on_deleted_at"
     t.index ["name_en"], name: "index_sites_on_name_en"
-  end
-
-  create_table "social_providers", force: :cascade do |t|
-    t.string "provider_name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "step_values", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_16_103847) do
+ActiveRecord::Schema.define(version: 2021_07_28_091824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -35,6 +35,48 @@ ActiveRecord::Schema.define(version: 2021_07_16_103847) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "ahoy_events", force: :cascade do |t|
+    t.bigint "visit_id"
+    t.bigint "user_id"
+    t.string "name"
+    t.jsonb "properties"
+    t.datetime "time"
+    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
+    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
+    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
+  end
+
+  create_table "ahoy_visits", force: :cascade do |t|
+    t.string "visit_token"
+    t.string "visitor_token"
+    t.bigint "user_id"
+    t.string "ip"
+    t.text "user_agent"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.text "landing_page"
+    t.string "browser"
+    t.string "os"
+    t.string "device_type"
+    t.string "country"
+    t.string "region"
+    t.string "city"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_term"
+    t.string "utm_content"
+    t.string "utm_campaign"
+    t.string "app_version"
+    t.string "os_version"
+    t.string "platform"
+    t.datetime "started_at"
+    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
+    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
   end
 
   create_table "identities", force: :cascade do |t|
@@ -160,6 +202,12 @@ ActiveRecord::Schema.define(version: 2021_07_16_103847) do
     t.string "name_km"
     t.index ["deleted_at"], name: "index_sites_on_deleted_at"
     t.index ["name_en"], name: "index_sites_on_name_en"
+  end
+
+  create_table "social_providers", force: :cascade do |t|
+    t.string "provider_name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "step_values", force: :cascade do |t|
@@ -303,7 +351,7 @@ ActiveRecord::Schema.define(version: 2021_07_16_103847) do
   create_table "variable_values", force: :cascade do |t|
     t.string "raw_value", null: false
     t.string "mapping_value_en", default: ""
-    t.string "status", default: "1"
+    t.string "value_status", default: "1"
     t.bigint "variable_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_28_091824) do
+ActiveRecord::Schema.define(version: 2021_07_29_091739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 2021_07_28_091824) do
     t.string "gender", default: ""
     t.boolean "repeated", default: false
     t.string "source_id", null: false
+    t.datetime "engaged_at", default: -> { "CURRENT_TIMESTAMP" }
   end
 
   create_table "settings", force: :cascade do |t|

--- a/lib/tasks/session.rake
+++ b/lib/tasks/session.rake
@@ -99,4 +99,13 @@ namespace :session do
         end
     end
   end
+
+  desc "Copy created at to engaged at"
+  task migrate_engaged_at: :environment do
+    Session.reset_column_information
+    Session.record_timestamps = false
+    Session.update_all('engaged_at=created_at')
+  ensure
+    Session.record_timestamps = true
+  end
 end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -38,5 +38,10 @@ FactoryBot.define do
     trait :completed do
       status { 'completed' }
     end
+
+    trait :kamrieng do
+      province_id { '02' }
+      district_id { '0212' }
+    end
   end
 end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -21,9 +21,22 @@ FactoryBot.define do
     district_id { "02122334" }
     province_id { district_id[0..1] }
     last_interaction_at { "2020-08-24 08:29:17" }
+    gender { %w(male female).sample }
 
     before(:create) do |session, evaluator|
       session.source_id = session.session_id
+    end
+
+    trait :messenger do
+      platform_name { "Messenger" }
+    end
+
+    trait :incomplete do
+      status { 'incomplete' }
+    end
+
+    trait :completed do
+      status { 'completed' }
     end
   end
 end

--- a/spec/factories/variable_values.rb
+++ b/spec/factories/variable_values.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     raw_value { "certify_docs" }
     mapping_value_en { "Certify Documents" }
     mapping_value_km { "បញ្ជាក់ឯកសារ" }
-    status { "1" }
+    value_status { "1" }
     association :variable
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Session, type: :model do
     end
   end
 
-  #   
   describe ".create_or_return" do
     let(:session) { build(:session, :messenger, :incomplete, session_id: 1, source_id: 1) }
 
@@ -82,9 +81,9 @@ RSpec.describe Session, type: :model do
       end
     end
 
-    xcontext "completion" do
+    context "completion" do
       it "clones when starts new session" do
-        old_session = create(:session, province_id: '12', district_id: '1234', session_id: 1, source_id: 1)
+        old_session = create(:session, :messenger, province_id: '12', district_id: '1234', session_id: 1, source_id: 1)
         old_session.completed!
 
         new_session = described_class.create_or_return("Messenger", old_session.session_id)
@@ -104,24 +103,22 @@ RSpec.describe Session, type: :model do
     end
   end
 
-  xdescribe "#last_completed" do
-    let(:session) { create(:session) }
-    let!(:session1) { create(:session, :completed) }
-    let!(:session2) { create(:session) }
-    let!(:session3) { create(:session) }
+  describe "#last_completed" do
+    let!(:session1) { create(:session, :messenger, :completed, :kamrieng) }
+    let!(:session2) { create(:session, :messenger, :incomplete, session_id: 2) }
+    let!(:session3) { create(:session, :messenger, session_id: session1.session_id) }
 
     it "#last_completed" do
-      byebug
       expect(session3.last_completed).to eq(session1)
     end
   end
 
-  xdescribe "#clone" do
+  describe "#clone" do
     let!(:gender) { create(:variable, :gender) }
     let!(:district) { create(:variable, :district) }
 
     it "clones relations" do
-      old_session = create(:session, district_id: '0204', gender: 'male')
+      old_session = create(:session, :kamrieng, gender: 'male')
       old_session.completed!
 
       new_session = create(:session)

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -16,6 +16,120 @@
 require 'rails_helper'
 
 RSpec.describe Session, type: :model do
+  # Attributes
+  it { is_expected.to have_attribute(:engaged_at) }
+  it { is_expected.to have_attribute(:gender) }
+  it { is_expected.to have_attribute(:last_interaction_at) }
+  it { is_expected.to have_attribute(:platform_name) }
+  it { is_expected.to have_attribute(:repeated) }
+  it { is_expected.to have_attribute(:session_type) }
+  it { is_expected.to have_attribute(:district_id) }
+  it { is_expected.to have_attribute(:province_id) }
+  it { is_expected.to have_attribute(:session_id) }
+  it { is_expected.to have_attribute(:source_id) }
   it { is_expected.to define_enum_for(:status).with_values(%i[incomplete completed]) }
+
+  # Associations
   it { is_expected.to have_many(:trackings) }
+  it { is_expected.to have_many(:step_values) }
+
+  # Validations
+  context 'Within validation' do
+    let(:session) { build(:session) }
+
+    it { is_expected.to validate_presence_of(:session_id) }
+    it { is_expected.to validate_presence_of(:source_id) }
+
+    context 'when :platform_name is nil' do
+      it 'validates :platform_name' do
+        session.platform_name = nil
+        expect(session).to be_invalid  
+      end
+    end
+
+    context 'when :platform_name is invalid' do
+      it 'validates :platform_name' do
+        session.platform_name = 'INVALID_PLATFORM'
+        expect(session).to be_invalid  
+      end
+    end
+
+    context 'when :platform_name is valid' do
+      it 'validates :platform_name' do
+        session.platform_name = 'Messenger'
+        expect(session).to be_valid  
+      end
+    end
+  end
+
+  #   
+  describe ".create_or_return" do
+    let(:session) { build(:session, :messenger, :incomplete, session_id: 1, source_id: 1) }
+
+    context "existence" do
+      it "create a new session if not exist" do
+        expect {
+          described_class.create_or_return("Messenger", session.session_id)
+        }.to(change { Session.count })
+      end
+
+      it "returns if already created" do
+        session.save!
+
+        expect do
+          described_class.create_or_return("Messenger", session.session_id)
+        end.not_to(change { Session.count })
+      end
+    end
+
+    xcontext "completion" do
+      it "clones when starts new session" do
+        old_session = create(:session, province_id: '12', district_id: '1234', session_id: 1, source_id: 1)
+        old_session.completed!
+
+        new_session = described_class.create_or_return("Messenger", old_session.session_id)
+        new_session.reload
+
+        expect(old_session.province_id).to eq(new_session.province_id)
+        expect(old_session.district_id).to eq(new_session.district_id)
+      end
+    end
+  end
+
+  describe "#completed?" do
+    let(:session) { build(:session) }
+
+    it "is not complete" do
+      expect(session).to be_incomplete
+    end
+  end
+
+  xdescribe "#last_completed" do
+    let(:session) { create(:session) }
+    let!(:session1) { create(:session, :completed) }
+    let!(:session2) { create(:session) }
+    let!(:session3) { create(:session) }
+
+    it "#last_completed" do
+      byebug
+      expect(session3.last_completed).to eq(session1)
+    end
+  end
+
+  xdescribe "#clone" do
+    let!(:gender) { create(:variable, :gender) }
+    let!(:district) { create(:variable, :district) }
+
+    it "clones relations" do
+      old_session = create(:session, district_id: '0204', gender: 'male')
+      old_session.completed!
+
+      new_session = create(:session)
+      allow(new_session).to receive(:last_completed_before).and_return old_session
+
+      expect {
+        new_session.clone
+      }.to change { StepValue.count }
+    end
+  end
 end

--- a/spec/models/variable_value_spec.rb
+++ b/spec/models/variable_value_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe VariableValue, type: :model do
   it { is_expected.to have_attribute(:mapping_value_km) }
   it { is_expected.to have_attribute(:hint) }
   it { is_expected.to have_attribute(:raw_value) }
-  it { is_expected.to have_attribute(:status) }
+  it { is_expected.to have_attribute(:value_status) }
   it { is_expected.to have_attribute(:step_values_count) }
   it { is_expected.to belong_to(:variable) }
 


### PR DESCRIPTION

# Session
  1. `engaged_at` : get update after save each steps
  2. Update `Session.filter` from `created_at` to `engaged_at`

# DashboardQuery
  1. Update all filter base on session (before some charts use session filter and others use step value filter)

# Step Value
  1. Touch session `engaged_at` on save

# Variable Value
  1. Update `:status` -> `:value_status`
    1.1 Issue description: 
      mapping by enum produce incorrect mapping between Session#status and VariableValue#status (both have the same attribute called `status`)

    ## Steps to reproduce
    ```
    Session...
            .joins(step_values: [:variable, :variable_value])
            .group('variable_value.status')
            .count
        
        => { session_status1: variable_value_count1, ...}
    ```
    ## Expected behavior
      { variable_value_status1: variable_value_count1, ...}
