### PR TITLE
Fixed provincial usage when filter non location (IVR)

### DIFF
--- a/app/decorators/provincial_usage_decorator.rb
+++ b/app/decorators/provincial_usage_decorator.rb
@@ -16,6 +16,7 @@ class ProvincialUsageDecorator < ApplicationDecorator
     return "" unless most_request_service.present?
 
     name, count, total = most_request_service
-    "#{name} (#{count}/#{total})"
+    info = "(#{count}/#{total})" if count.to_i > 0
+    [name, info].compact.join(' ')
   end
 end

--- a/app/models/provincial_usage.rb
+++ b/app/models/provincial_usage.rb
@@ -14,19 +14,19 @@ class ProvincialUsage
   end
 
   def visits_count
-    result[pro_code][:visits]
+    result&.dig(pro_code, :visits).to_i
   end
 
   def unique_users_count
-    result[pro_code][:uniques]
+    result&.dig(pro_code, :uniques).to_i
   end
 
   def service_delivered_count
-    result[pro_code][:service_delivered]
+    result&.dig(pro_code, :service_delivered).to_i
   end
 
   def most_request_service
-    result[pro_code][:most_request_services]
+    result&.dig(pro_code, :most_request_services)
   end
 
   def self.fetch_and_transform(options)

--- a/app/models/provincial_usage.rb
+++ b/app/models/provincial_usage.rb
@@ -14,19 +14,19 @@ class ProvincialUsage
   end
 
   def visits_count
-    result&.dig(pro_code, :visits).to_i
+    (result_scope && result_scope[:visits]).to_i
   end
 
   def unique_users_count
-    result&.dig(pro_code, :uniques).to_i
+    (result_scope && result_scope[:uniques]).to_i
   end
 
   def service_delivered_count
-    result&.dig(pro_code, :service_delivered).to_i
+    (result_scope && result_scope[:service_delivered]).to_i
   end
 
   def most_request_service
-    result&.dig(pro_code, :most_request_services)
+    result_scope && result_scope[:most_request_services]
   end
 
   def self.fetch_and_transform(options)
@@ -35,6 +35,10 @@ class ProvincialUsage
   end
 
   private
+
+  def result_scope
+    result[pro_code]
+  end
 
   def address_i18n
     "address_#{I18n.locale}".to_sym

--- a/app/models/provincial_usages.rb
+++ b/app/models/provincial_usages.rb
@@ -10,7 +10,7 @@ class ProvincialUsages
 
     @provincial_usages.sort do |left, right|
       left, right = [right, left] if desc?(dir)
-      left.send(attr.to_sym).to_i <=> right.send(attr.to_sym).to_i
+      left.send(attr.to_sym) <=> right.send(attr.to_sym)
     rescue NoMethodError => e
       raise Exception.new err_with_suggestion(e)
     end

--- a/spec/models/provincial_usage_spec.rb
+++ b/spec/models/provincial_usage_spec.rb
@@ -1,34 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe ProvincialUsage do
-  let(:result) { {"08" => { visits: 1, uniques: 2, service_delivered: 3, most_request_services: 4 }} }
   let(:provincial_usage) { build(:provincial_usage, result: result, pro_code: '08') }
 
-  subject { ProvincialUsage }
+  context "with IVR" do
+    context "when province_id does not exists" do
+      let(:result) { {nil => { visits: 1, uniques: 2, service_delivered: 3, most_request_services: 4 }} }
 
-  it "#province_name" do
-    expect(provincial_usage.province_name).to eq 'Kandal Province'
+      it "#visits_count" do
+        expect(provincial_usage.visits_count).to eq 0
+      end
+
+      it '#unique_users_count' do
+        expect(provincial_usage.unique_users_count).to eq 0
+      end
+
+      it '#service_delivered_count' do
+        expect(provincial_usage.service_delivered_count).to eq 0
+      end
+
+      it '#most_request_service' do
+        expect(provincial_usage.most_request_service).to be_nil
+      end
+    end
   end
 
-  it "#visits_count" do
-    expect(provincial_usage.visits_count).to eq 1
-  end
+  context "with Messenger" do
+    context "when province_id exists" do
+      let(:result) { {"08" => { visits: 1, uniques: 2, service_delivered: 3, most_request_services: 4 }} }
 
-  it '#unique_users_count' do
-    expect(provincial_usage.unique_users_count).to eq 2
-  end
+      subject { ProvincialUsage }
 
-  it '#service_delivered_count' do
-    expect(provincial_usage.service_delivered_count).to eq 3
-  end
+      it "#province_name" do
+        expect(provincial_usage.province_name).to eq 'Kandal Province'
+      end
 
-  it '#most_request_service' do
-    expect(provincial_usage.most_request_service).to eq 4
-  end
+      it "#visits_count" do
+        expect(provincial_usage.visits_count).to eq 1
+      end
 
-  it '.fetch_and_transform' do
-    expect(subject).to receive(:fetch)
-    expect(subject).to receive(:transform)
-    subject.fetch_and_transform({})
+      it '#unique_users_count' do
+        expect(provincial_usage.unique_users_count).to eq 2
+      end
+
+      it '#service_delivered_count' do
+        expect(provincial_usage.service_delivered_count).to eq 3
+      end
+
+      it '#most_request_service' do
+        expect(provincial_usage.most_request_service).to eq 4
+      end
+
+      it '.fetch_and_transform' do
+        expect(subject).to receive(:fetch)
+        expect(subject).to receive(:transform)
+        subject.fetch_and_transform({})
+      end
+    end
   end
 end


### PR DESCRIPTION
### Issue description
Currently, we don't capture user's location from **IVR**. so, instead of raising an error, provincial usage should be rendered properly with empty result.

![image](https://user-images.githubusercontent.com/5484758/129532530-5a429cf0-7bec-4c3e-8065-008a6141bd29.png)
