### PR TITLE
Redirect /:locale to /

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
+  get '/:locale', to: redirect('/'), constraints: { locale: /en|km/ }
+
   scope "(:locale)", locale: /en|km/ do
     root "welcomes#index"
     get :dashboard, to: "dashboard#show"


### PR DESCRIPTION
When user navigate to `/:locale`, user cannot change language by switching dropdown button,
this is fixed by redirect user to `/`.