### PR TITLE
Clear visitor count before launch

### DIFF
--- a/app.env.example
+++ b/app.env.example
@@ -40,3 +40,4 @@ PDF_TITLE=DO report
 # telegram bot
 TELEGRAM_CALLBACK_URL=https://domain.com/telegram
 MANUAL_ENABLED=true
+PUBLIC_START_DATE=2021/07/27

--- a/lib/tasks/ahoy_visit.rake
+++ b/lib/tasks/ahoy_visit.rake
@@ -1,0 +1,13 @@
+namespace :ahoy_visit do
+  desc "Clear ahoy visitor count"
+  task clear: :environment do
+    conn = ActiveRecord::Base.connection
+    ActiveRecord::Base.transaction do
+      raise "Must specify PUBLIC_START_DATE" unless ENV["PUBLIC_START_DATE"].present?
+      raise "Prevent from accidentally run in the future" if Date.current > "2021-09-10".to_date
+
+      conn.execute("DELETE FROM ahoy_visits WHERE DATE(started_at) < '#{ENV["PUBLIC_START_DATE"]}'")
+      conn.execute("DELETE FROM social_providers;")
+    end
+  end
+end


### PR DESCRIPTION
The corresponding models for `ahoy_visits` and `social_providers` are on `dashboard` branch.
but migration cannot be done on dashboard (readonly)

```
1. PUBLIC_START_DATE=2021/07/27
2. rails ahoy_visit:clear
```