### PR TITLE
Fixed telegram send duplicate report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ IDEA/
 /config/credentials/production.key
 
 pdfs/*.pdf
+yarn.lock

--- a/app.env.example
+++ b/app.env.example
@@ -39,5 +39,4 @@ PDF_TITLE=DO report
 
 # telegram bot
 TELEGRAM_CALLBACK_URL=https://domain.com/telegram
-SCHEDULE_MANUAL_CRON_ENABLED=true
 ENABLE_TG_DO_MONTHLY_REPORT=false

--- a/app.env.example
+++ b/app.env.example
@@ -40,3 +40,4 @@ PDF_TITLE=DO report
 # telegram bot
 TELEGRAM_CALLBACK_URL=https://domain.com/telegram
 MANUAL_ENABLED=true
+ENABLE_TG_DO_MONTHLY_REPORT=false

--- a/app.env.example
+++ b/app.env.example
@@ -39,5 +39,5 @@ PDF_TITLE=DO report
 
 # telegram bot
 TELEGRAM_CALLBACK_URL=https://domain.com/telegram
-MANUAL_ENABLED=true
+SCHEDULE_MANUAL_CRON_ENABLED=true
 ENABLE_TG_DO_MONTHLY_REPORT=false

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -58,4 +58,8 @@ class Setting < RailsSettings::Base
   def self.fb_reachable_period
     (ENV["FB_REACHABLE_DAY"] || 1).to_i
   end
+
+  def self.admin_view?
+    ENV["DASHBOARD_VIEW"].to_s == "private"
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -59,7 +59,7 @@ class Setting < RailsSettings::Base
     (ENV["FB_REACHABLE_DAY"] || 1).to_i
   end
 
-  def self.admin_view?
-    ENV["DASHBOARD_VIEW"].to_s == "private"
+  def self.enabled_telegram_do_report?
+    ENV["ENABLE_TG_DO_MONTHLY_REPORT"].to_s == "true"
   end
 end

--- a/app/views/schedules/_form.html.haml
+++ b/app/views/schedules/_form.html.haml
@@ -17,7 +17,7 @@
           = f.input_field :time, type: "time", class: "form-control cron-control cron-time"
           = f.error :time, class: 'position-absolute error-hint'
 
-      - if ENV['SCHEDULE_MANUAL_CRON_ENABLED'] == 'true'
+      - if Rails.env.development?
         %input.toggle-control#enable_manual_cron{ type: "checkbox" }
         %label{for: "enable_manual_cron"}= t "schedules.manual"
         = image_tag "info.png", id: "info", style: "width: 16px; vertical-align: super;"

--- a/app/views/schedules/_form.html.haml
+++ b/app/views/schedules/_form.html.haml
@@ -17,7 +17,7 @@
           = f.input_field :time, type: "time", class: "form-control cron-control cron-time"
           = f.error :time, class: 'position-absolute error-hint'
 
-      - if ENV['MANUAL_ENABLED'] == 'true'
+      - if ENV['SCHEDULE_MANUAL_CRON_ENABLED'] == 'true'
         %input.toggle-control#enable_manual_cron{ type: "checkbox" }
         %label{for: "enable_manual_cron"}= t "schedules.manual"
         = image_tag "info.png", id: "info", style: "width: 16px; vertical-align: super;"

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -3,7 +3,7 @@ require 'sidekiq-scheduler'
 
 Sidekiq.configure_server do |config|
   config.on(:startup) do
-    if Setting.admin_view?
+    if Setting.enabled_telegram_do_report?
       Schedule.find_each do |schedule|
         schedule.set_schedule
       end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -3,8 +3,10 @@ require 'sidekiq-scheduler'
 
 Sidekiq.configure_server do |config|
   config.on(:startup) do
-    Schedule.find_each do |schedule|
-      schedule.set_schedule
+    if Setting.admin_view?
+      Schedule.find_each do |schedule|
+        schedule.set_schedule
+      end
     end
   end
 end


### PR DESCRIPTION
## Issue description

- Deploy `public dashboard` and `admin dashboard` cause duplicate schedule launch.

__Environment variables:__
```yaml
# 1. Either public or admin dashboard (can't be both)

ENABLE_TG_DO_MONTHLY_REPORT=true

# 2. Rename variable
# MANUAL_ENABLED -> SCHEDULE_MANUAL_CRON_ENABLED
```