### PR TITLE
Hotfix most track periodic

### DIFF
--- a/app/queries/most_tracked_periodic.rb
+++ b/app/queries/most_tracked_periodic.rb
@@ -14,10 +14,10 @@ class MostTrackedPeriodic < BasicReport
 
   private
     def result_set
-      scope = Ticket.filter(@query.options)
-      scope = scope.joins(""" INNER JOIN trackings ON
+      scope = Tracking.filter(@query.options)
+      scope = scope.joins(""" INNER JOIN tickets ON
                               trackings.ticket_code = tickets.code""")
-      scope = scope.group_by_period(period, "trackings.created_at", format: "%b/%y,%Y")
+      scope = scope.group_by_period(period, "trackings.tracking_datetime", format: "%b/%y,%Y")
       scope = scope.group(:sector)
       scope.count
     end


### PR DESCRIPTION
# issue
`most popular by ` visualization return wrong data

![image](https://user-images.githubusercontent.com/5484758/143556843-fcbdf589-fda0-4078-99f0-c30962fd3271.png)

![image](https://user-images.githubusercontent.com/5484758/143556757-ade24911-4c05-4218-a642-9ea1de530a3b.png)

# root cause:
Wrong query logic in `app/queries/most_tracked_periodic.rb`, 
filter date on `Ticket#requested_date` and Tracking#tracking_datetime in e.g:

Ticket 1: `code: 123456, requested_date: 2021/09/01` and Tracking 1: `ticket_code: 123456, tracking_datetime: 2021/11/01`

So when we filter data for `Nov-2021` with `Ticket#requested_date` => empty

Solution:
  should query via `Tracking#requested_datetime`