### PR TITLE
Hotfixed wrong group date

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -103,7 +103,7 @@ class Session < ApplicationRecord
     scope = filter(options)
     scope = scope.joins(:step_values)
     scope = scope.where(step_values: { variable: Variable.service_accessed })
-    scope = scope.group_by_period(period, :created_at, format: format)
+    scope = scope.group_by_period(period, :engaged_at, format: format)
     scope.count
   end
 

--- a/app/queries/feedback_trend.rb
+++ b/app/queries/feedback_trend.rb
@@ -42,7 +42,7 @@ class FeedbackTrend < Feedback
               .where(step_values: { variable: @variable })\
               .where(feedback_province_id: @query.province_codes)\
               .where(feedback_district_id: @query.district_codes)\
-              .group_by_period(period, :created_at, format: '%b/%y,%Y')\
+              .group_by_period(period, :engaged_at, format: '%b/%y,%Y')\
               .group(:variable_value_id)\
               .count
     end


### PR DESCRIPTION
# Wrong group date

This bug happen when _filter field (sessions:engaged_at)_ is **different** from _grouping field(sessions.created_at)_. 

In this case, in `models/session.rb`

By include `Session::FilterableConcern`

When filter sessions collection, we call `#filter` method passed in dashboard query as arguments then using `engaged_at` as date filter field using `DATE(sessions.engaged_at) BETWEEN ? and ?`, however after collection return from SQL query, the grouping field called inside `.accessed` method invoked `created_at` e.g. `group_by_period(period, :created_at, ...` that the root cause of inconsistent.