### PR TITLE
Migrate missing feedback location

### DIFF
--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -9,7 +9,7 @@ class FeedbackSession
     from_date = from_str_date.to_date rescue (raise InvalidDateFormatError)
     to_date   = to_str_date.to_date   rescue (raise InvalidDateFormatError)
 
-    raise InvalidDateRangeError if from_date >= to_date
+    raise InvalidDateRangeError if from_date > to_date
 
     Session.joins(:step_values)\
           .where("DATE(sessions.engaged_at) >= :from AND 

--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -1,9 +1,10 @@
 class FeedbackSession
+  class FeedbackVariableRequiredError < StandardError; end
   class WrongDateFormatError < StandardError; end
   class InvalidDateError < StandardError; end
 
   def self.missing(from_str_date, to_str_date)
-    raise "feedback variable must be present" unless Variable.feedback
+    raise FeedbackVariableRequiredError unless Variable.feedback
 
     from_date = from_str_date.to_date rescue (raise WrongDateFormatError)
     to_date   = to_str_date.to_date   rescue (raise WrongDateFormatError)

--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -1,15 +1,15 @@
 class FeedbackSession
   class FeedbackVariableRequiredError < StandardError; end
-  class WrongDateFormatError < StandardError; end
-  class InvalidDateError < StandardError; end
+  class InvalidDateFormatError < StandardError; end
+  class InvalidDateRangeError < StandardError; end
 
-  def self.missing(from_str_date, to_str_date)
-    raise FeedbackVariableRequiredError unless Variable.feedback
+  def self.missing_location(from_str_date, to_str_date)
+    raise FeedbackVariableRequiredError if Variable.feedback.nil?
 
-    from_date = from_str_date.to_date rescue (raise WrongDateFormatError)
-    to_date   = to_str_date.to_date   rescue (raise WrongDateFormatError)
+    from_date = from_str_date.to_date rescue (raise InvalidDateFormatError)
+    to_date   = to_str_date.to_date   rescue (raise InvalidDateFormatError)
 
-    raise InvalidDateError if from_date >= to_date
+    raise InvalidDateRangeError if from_date >= to_date
 
     Session.joins(:step_values)\
           .where("DATE(sessions.engaged_at) >= :from AND 

--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -5,8 +5,8 @@ class FeedbackSession
   def self.missing(from_str_date, to_str_date)
     raise "feedback variable must be present" unless Variable.feedback
 
-    from_date = from_str_date.to_date rescue raise WrongDateFormatError
-    to_date   = to_str_date.to_date   rescue raise WrongDateFormatError
+    from_date = from_str_date.to_date rescue (raise WrongDateFormatError)
+    to_date   = to_str_date.to_date   rescue (raise WrongDateFormatError)
 
     raise InvalidDateError if from_date >= to_date
 

--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -1,0 +1,20 @@
+class FeedbackSession
+  class WrongDateFormatError < StandardError; end
+  class InvalidDateError < StandardError; end
+
+  def self.missing(from_str_date, to_str_date)
+    raise "feedback variable must be present" unless Variable.feedback
+
+    from_date = from_str_date.to_date rescue raise WrongDateFormatError
+    to_date   = to_str_date.to_date   rescue raise WrongDateFormatError
+
+    raise InvalidDateError if from_date >= to_date
+
+    Session.joins(:step_values)\
+          .where("DATE(sessions.engaged_at) >= :from AND 
+                  DATE(sessions.engaged_at) <= :to", from: from_date, to: to_date)\
+          .where("sessions.feedback_province_id IS NULL OR 
+                  sessions.feedback_district_id IS NULL")\
+          .where(step_values: { variable: Variable.feedback })
+  end
+end

--- a/lib/tasks/session.rake
+++ b/lib/tasks/session.rake
@@ -179,9 +179,9 @@ namespace :session do
         end
       end
 
-    rescue WrongDateFormatError
+    rescue FeedbackSession::WrongDateFormatError
       puts "Invalid date format"
-    rescue InvalidDateError
+    rescue FeedbackSession::InvalidDateError
       puts "to_date must be greater than from_date"
     ensure
       Session.record_timestamps = true

--- a/lib/tasks/session.rake
+++ b/lib/tasks/session.rake
@@ -175,6 +175,8 @@ namespace :session do
           step.save! if step.variable.feedback_province?
           step.save! if step.variable.feedback_district?
         end
+      rescue FeedbackSession::FeedbackVariableRequiredError
+        puts "Feedback variable is required"
       rescue FeedbackSession::WrongDateFormatError
         puts "Invalid date format"
       rescue FeedbackSession::InvalidDateError

--- a/lib/tasks/session.rake
+++ b/lib/tasks/session.rake
@@ -166,28 +166,25 @@ namespace :session do
 
   desc "Migrate missing feedback location"
   task :migrate_missing_feedback_location, [:from_date, :to_date] => :environment do |t, args|
-    # Api: FeedbackSession.missing(from: ..., to: ...)
-    missing_feedback_location_sessions = Session.joins(:step_values)\
-    .where("DATE(sessions.created_at) >= :from AND 
-            DATE(sessions.created_at) <= :to", from: args[:from_date], to: args[:to_date])\
-    .where("sessions.feedback_province_id IS NULL OR 
-            sessions.feedback_district_id IS NULL")\
-    .where(step_values: { variable: Variable.feedback })
-  end
+    begin
+      missing_feedback_location_sessions = FeedbackSession.missing(args[:from_date]), args[:to_date])
 
-  begin
-    Session.record_timestamps = false
-    Session.transaction do
-      missing_feedback_location_sessions.find_each do |session|
-        session.step_values.each do |step|
-          step.save! if step.variable.feedback_province?
-          step.save! if step.variable.feedback_district?
+      Session.record_timestamps = false
+      Session.transaction do
+        missing_feedback_location_sessions.find_each do |session|
+          session.step_values.each do |step|
+            step.save! if step.variable.feedback_province?
+            step.save! if step.variable.feedback_district?
+          end
         end
       end
+
+    rescue WrongDateFormatError
+      puts "Invalid date format"
+    rescue InvalidDateError
+      puts "to_date must be greater than from_date"
+    ensure
+      Session.record_timestamps = true
     end
-  rescue => e
-    puts "Exception found: #{e.message}"
-  ensure
-    Session.record_timestamps = true
   end
 end

--- a/lib/tasks/session.rake
+++ b/lib/tasks/session.rake
@@ -166,7 +166,7 @@ namespace :session do
 
   desc "Migrate missing feedback location"
   task :migrate_missing_feedback_location, [:from_date, :to_date] => :environment do |t, args|
-    missing_feedback_location_sessions = FeedbackSession.missing(args[:from_date], args[:to_date])
+    missing_feedback_location_sessions = FeedbackSession.missing_location(args[:from_date], args[:to_date])
 
     Session.record_timestamps = false
     Session.transaction do
@@ -177,9 +177,9 @@ namespace :session do
         end
       rescue FeedbackSession::FeedbackVariableRequiredError
         puts "Feedback variable is required"
-      rescue FeedbackSession::WrongDateFormatError
+      rescue FeedbackSession::InvalidDateFormatError
         puts "Invalid date format"
-      rescue FeedbackSession::InvalidDateError
+      rescue FeedbackSession::InvalidDateRangeError
         puts "to_date must be greater than from_date"
       ensure
         Session.record_timestamps = true

--- a/spec/factories/step_values.rb
+++ b/spec/factories/step_values.rb
@@ -59,9 +59,18 @@ FactoryBot.define do
       association :variable_value, raw_value: "01"
     end
 
+    trait :feedback_variable do
+      association :variable, name: 'feedback_rating', mark_as: 'feedback'
+    end
+
+    trait :feedback_value do
+      association :variable_value, raw_value: "1"
+    end
+
     factory :district_step, traits: [:district_variable, :district_value]
     factory :province_step, traits: [:province_variable, :province_value]
     factory :feedback_district_step, traits: [:feedback_district_variable, :district_value]
     factory :feedback_province_step, traits: [:feedback_province_variable, :province_value]
+    factory :feedback_step, traits: [:feedback_variable, :feedback_value]
   end
 end

--- a/spec/factories/variable.rb
+++ b/spec/factories/variable.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   factory :variable do
     name { FFaker::Name.unique.first_name }
+
+    trait :feedback do
+      name { "feedback" }
+      mark_as { "feedback" }
+    end
   end
 
   trait :ticket_tracking do

--- a/spec/models/feedback_session_spec.rb
+++ b/spec/models/feedback_session_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe FeedbackSession do
+  describe ".missing" do
+    context "without feedback variable" do
+      it "raises when no feedback variable" do
+        expect {
+          described_class.missing
+        }.to raise_error "feedback variable must be present"
+      end
+    end
+
+
+    context "with feedback variable" do
+      let(:feedback_province_step) { create(:feedback_province_step) }
+      let(:feedback_district_step) { create(:feedback_district_step) }
+
+      let!(:missing_feedback_location) { create(:session, feedback_province_id: nil, step_values: [feedback_province_step, feedback_district_step]) }
+
+      before { create(:variable, :feedback) }
+      
+      it "returns missing feedback location" do
+        expect(described_class.missing).to include missing_feedback_location
+      end
+
+      it "exists in step values" do
+        expect(StepValue.all).to contain_exactly(feedback_province_step, feedback_district_step)
+      end
+    end
+  end
+end

--- a/spec/models/feedback_session_spec.rb
+++ b/spec/models/feedback_session_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe FeedbackSession do
 
       let!(:missing_feedback_location) { create(:session, feedback_province_id: nil, step_values: [feedback_step, feedback_province_step, feedback_district_step]) }
 
-      # before { create(:variable, :feedback) }
-
       context "with wrong date format" do
         it "raises error" do
           expect {

--- a/spec/models/feedback_session_spec.rb
+++ b/spec/models/feedback_session_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe FeedbackSession do
   let(:from_date) { Date.current.beginning_of_month }
   let(:to_date) { Date.current.at_end_of_month }
 
-  describe ".missing" do
+  describe ".missing_location" do
     context "without feedback variable" do
       it "raises when no feedback variable" do
         expect {
-          described_class.missing(from_date, to_date)
+          described_class.missing_location(from_date, to_date)
         }.to raise_error FeedbackSession::FeedbackVariableRequiredError
       end
     end
@@ -23,21 +23,21 @@ RSpec.describe FeedbackSession do
       context "with wrong date format" do
         it "raises error" do
           expect {
-            described_class.missing '2021', '2022'
-          }.to raise_error FeedbackSession::WrongDateFormatError
+            described_class.missing_location '2021', '2022'
+          }.to raise_error FeedbackSession::InvalidDateFormatError
         end
       end
 
       context "with from_date greater than to_date" do
         it "raises error" do
           expect {
-            described_class.missing to_date, from_date
-          }.to raise_error FeedbackSession::InvalidDateError
+            described_class.missing_location to_date, from_date
+          }.to raise_error FeedbackSession::InvalidDateRangeError
         end
       end
       
       it "returns missing feedback location" do
-        expect(described_class.missing(from_date, to_date)).to include missing_feedback_location
+        expect(described_class.missing_location(from_date, to_date)).to include missing_feedback_location
       end
 
       it "exists in step values" do

--- a/spec/models/feedback_session_spec.rb
+++ b/spec/models/feedback_session_spec.rb
@@ -1,30 +1,49 @@
 require "rails_helper"
 
 RSpec.describe FeedbackSession do
+  let(:from_date) { Date.current.beginning_of_month }
+  let(:to_date) { Date.current.at_end_of_month }
+
   describe ".missing" do
     context "without feedback variable" do
       it "raises when no feedback variable" do
         expect {
-          described_class.missing
+          described_class.missing(from_date, to_date)
         }.to raise_error "feedback variable must be present"
       end
     end
 
-
     context "with feedback variable" do
+      let(:feedback_step) { create(:feedback_step) }
       let(:feedback_province_step) { create(:feedback_province_step) }
       let(:feedback_district_step) { create(:feedback_district_step) }
 
-      let!(:missing_feedback_location) { create(:session, feedback_province_id: nil, step_values: [feedback_province_step, feedback_district_step]) }
+      let!(:missing_feedback_location) { create(:session, feedback_province_id: nil, step_values: [feedback_step, feedback_province_step, feedback_district_step]) }
 
-      before { create(:variable, :feedback) }
+      # before { create(:variable, :feedback) }
+
+      context "with wrong date format" do
+        it "raises error" do
+          expect {
+            described_class.missing '2021', '2022'
+          }.to raise_error FeedbackSession::WrongDateFormatError
+        end
+      end
+
+      context "with from_date greater than to_date" do
+        it "raises error" do
+          expect {
+            described_class.missing to_date, from_date
+          }.to raise_error FeedbackSession::InvalidDateError
+        end
+      end
       
       it "returns missing feedback location" do
-        expect(described_class.missing).to include missing_feedback_location
+        expect(described_class.missing(from_date, to_date)).to include missing_feedback_location
       end
 
       it "exists in step values" do
-        expect(StepValue.all).to contain_exactly(feedback_province_step, feedback_district_step)
+        expect(StepValue.all).to contain_exactly(feedback_step, feedback_province_step, feedback_district_step)
       end
     end
   end

--- a/spec/models/feedback_session_spec.rb
+++ b/spec/models/feedback_session_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FeedbackSession do
       it "raises when no feedback variable" do
         expect {
           described_class.missing(from_date, to_date)
-        }.to raise_error "feedback variable must be present"
+        }.to raise_error FeedbackSession::FeedbackVariableRequiredError
       end
     end
 


### PR DESCRIPTION
# Bug's Story
Some sessions does not properly update feedback location.
Suspect issue need to further investigate is [`callback halt`](https://guides.rubyonrails.org/active_record_callbacks.html#halting-execution)

Another possible issue, related with chatfuel's json api services drop 1 POST request,
but after ask for support, they confirm that the request are performed from their end, while log in with our staging server with bong kakada, we can only see 2 requests of all 3 requests.

# Migrate missing feedback location to session
Find all sessions that has engaged at between FROM_DATE to TO_DATE and has no `feedback_province_id` or `feedback_district_id`, but step values still contains `feedback_province` or `feedback_district`.

Migrate step values to session's value

E.g
```ruby
session 1 : id = 100, feedback_province_id: nil, feedback_district_id: nil, step_values: [{ variable: { name: 'feedback_province' }, variable_value: { raw_value: "02" }}, {variable: { name: 'feedback_district' }, variable_value: { raw_value: "0299" }}]
# becomes
session 1 : id = 100, feedback_province_id: "02", feedback_district_id: "0299", step_values: [{ variable: { name: 'feedback_province' }, variable_value: { raw_value: "02" }}, {variable: { name: 'feedback_district' }, variable_value: { raw_value: "0299" }}]
```

# Migration
```
START_DATE = "2021/10/01"
TO_DATE = "2021/10/30"

rails 'session:migrate_missing_feedback_location[FROM_DATE, T0_DATE]'
```

# References
## chatfuel support team
![image](https://user-images.githubusercontent.com/5484758/144809153-11669cd3-0fb3-4500-b7e7-40ec54b56590.png)
![image](https://user-images.githubusercontent.com/5484758/144809178-2a661a40-aa9e-42a9-8426-c2753837b043.png)
## Issue chatbot block
![image](https://user-images.githubusercontent.com/5484758/144809334-c36ed5c6-141c-42d4-ab0d-951e5adcc57c.png)

## our end
![image](https://user-images.githubusercontent.com/5484758/144809256-73afdacb-ff2b-43b8-a49c-158d01c22b98.png)
