### PR TITLE
clone feedback location

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -74,6 +74,8 @@ class Session < ApplicationRecord
     step_values.clone_step :gender, gender
     step_values.clone_step :province, province_id
     step_values.clone_step :district, district_id
+    step_values.clone_step :feedback_province_id, feedback_province_id
+    step_values.clone_step :feedback_district_id, feedback_district_id
     self
   end
 
@@ -158,6 +160,6 @@ class Session < ApplicationRecord
     end
 
     def clone_attributes
-      %w(platform_name session_id source_id gender province_id district_id)
+      %w(platform_name session_id source_id gender province_id district_id feedback_province_id feedback_district_id)
     end
 end


### PR DESCRIPTION
Bug happens when 

user interact chatbot then finish feedback, then re-engage feedback flow again, system will automatically clone some values from the previous steps, not include feedback location. This cause the second feedback flow exists without location like

```
![image](https://user-images.githubusercontent.com/5484758/145568249-c5443004-6388-4bae-8449-02f0d5b7b34b.png)