### PR TITLE
Migrate chatfuel raw data in november

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,3 +51,4 @@ pdfs/*.pdf
 
 chatfuel_*.gz
 chatfuel_*.sql
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ app/assets/javascripts/i18n/
 public/javascripts/
 chatfuel_*.gz
 chatfuel_*.sql
+*.csv
 
 app/assets/javascripts/i18n/
 public/javascripts/

--- a/app/models/concerns/mark_as_concern.rb
+++ b/app/models/concerns/mark_as_concern.rb
@@ -8,7 +8,7 @@ module MarkAsConcern
     before_save :ensure_unique_most_request, if: :is_most_request?
   end
 
-  MARK_AS_LIST = %w(gender user_visit ticket_tracking service_accessed province district feedback_province feedback_district)
+  MARK_AS_LIST = %w(gender user_visit ticket_tracking service_accessed province district feedback_unit feedback_province feedback_district)
   WHITELIST_MARK_AS = [Variable::FEEDBACK, Variable::MOST_REQUEST] + MARK_AS_LIST
 
   define_method :feedback? do self.mark_as == Variable::FEEDBACK end

--- a/app/models/step_value.rb
+++ b/app/models/step_value.rb
@@ -123,6 +123,6 @@ class StepValue < ApplicationRecord
     end
 
     def engage_session
-      session.touch(:engaged_at) if session.present?
+      session.touch(:engaged_at) if session.present? && ENV['ENGAGED_AT_TIMSTAMPS'] == 'enabled'
     end
 end

--- a/app/queries/feedback_report.rb
+++ b/app/queries/feedback_report.rb
@@ -3,7 +3,6 @@ class FeedbackReport < GenericReport
     Session.feedback_filter(@query.options)\
             .joins(:step_values)\
             .where(step_values: { variable: [like, dislike] })\
-            .where(feedback_province_id: @query.province_codes)\
             .group(:variable_id, :variable_value_id)
   end
 

--- a/app/queries/feedback_trend.rb
+++ b/app/queries/feedback_trend.rb
@@ -40,8 +40,6 @@ class FeedbackTrend < Feedback
       Session.feedback_filter(@query.options)\
               .joins(:step_values)\
               .where(step_values: { variable: @variable })\
-              .where(feedback_province_id: @query.province_codes)\
-              .where(feedback_district_id: @query.district_codes)\
               .group_by_period(period, :engaged_at, format: '%b/%y,%Y')\
               .group(:variable_value_id)\
               .count

--- a/app/queries/overall_rating.rb
+++ b/app/queries/overall_rating.rb
@@ -33,7 +33,7 @@ class OverallRating < Feedback
     def mapping
       result_set.each_with_object({}) do |(key, count), hash|
         pro_code, district, value = find_objects_by(key)
-        district = district.send("name_#{I18n.locale}".to_sym) rescue 'n/a'
+        district = district.send("name_#{I18n.locale}".to_sym) rescue 'N/A'
       
         hash[pro_code] ||= {}
         hash[pro_code][district] ||= {}

--- a/app/queries/overall_rating.rb
+++ b/app/queries/overall_rating.rb
@@ -33,7 +33,7 @@ class OverallRating < Feedback
     def mapping
       result_set.each_with_object({}) do |(key, count), hash|
         pro_code, district, value = find_objects_by(key)
-        district = district.send("name_#{I18n.locale}".to_sym)
+        district = district.send("name_#{I18n.locale}".to_sym) rescue 'n/a'
       
         hash[pro_code] ||= {}
         hash[pro_code][district] ||= {}
@@ -51,8 +51,6 @@ class OverallRating < Feedback
       Session.feedback_filter(@query.options)
               .joins(:step_values)
               .where(step_values: { variable: @variable })
-              .where(feedback_province_id: @query.province_codes)
-              .where(feedback_district_id: @query.district_codes)
               .group(:feedback_province_id, :feedback_district_id, :variable_value_id)
               .count
     end

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -12,18 +12,22 @@ namespace :chatfuel do
 
   desc "Migrate missing session from chatfuel raw data"
   task migrate_missing_from_raw_data: :ensure_feedback_unit do
+    logs = {}
+
     StepValue.transaction do
       ::CSV.foreach(Rails.root.join("corrected-data-in-november.csv")) do |row|
         id, session_id, feedback_unit, feedback_province, feedback_district = row
-        
         session = Session.find_by(id: id)
         if session.present?
-          session.step_values.clone_step :feedback_unit, feedback_unit
-          session.step_values.clone_step :feedback_province, feedback_province
-          session.step_values.clone_step :feedback_district, feedback_district
-          puts "cloning #{session.id} is completed!"
+          logs[id] ||= []
+          logs[id] << session.step_values.clone_step(:feedback_unit, feedback_unit) if feedback_unit.present?
+          logs[id] << session.step_values.clone_step(:feedback_province, feedback_province) if feedback_province.present?
+          logs[id] << session.step_values.clone_step(:feedback_district, feedback_district) if feedback_district.present?
         end
       end
     end
+
+    puts "clone logs: "
+    puts logs.inspect
   end
 end

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -33,6 +33,6 @@ namespace :chatfuel do
     Session.record_timestamps = true
 
     puts "clone logs: "
-    puts logs.inspect
+    puts logs.keys.inspect
   end
 end

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -1,0 +1,16 @@
+require 'csv'
+
+namespace :chatfuel do
+  desc "Migrate missing session from chatfuel raw data"
+  task migrate_missing_from_raw_data: :environment do
+    ::CSV.foreach(Rails.root.join("corrected-data-in-november.csv")) do |row|
+      id, session_id, feedback_unit, feedback_province, feedback_district = row
+
+      StepValue.transaction do
+        s = Session.find(id)
+        s.step_values.clone_step :feedback_province, feedback_province
+        s.step_values.clone_step :feedback_district, feedback_district
+      end
+    end
+  end
+end

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -1,15 +1,28 @@
 require 'csv'
 
 namespace :chatfuel do
-  desc "Migrate missing session from chatfuel raw data"
-  task migrate_missing_from_raw_data: :environment do
-    ::CSV.foreach(Rails.root.join("corrected-data-in-november.csv")) do |row|
-      id, session_id, feedback_unit, feedback_province, feedback_district = row
+  desc "Ensure feedback unit is exists"
+  task ensure_feedback_unit: :environment do
+    feedback_unit = Variable.feedback_unit
+    if feedback_unit.nil?
+      feedback_unit = Variable.find_by(name: "feedback_unit")
+      feedback_unit&.mark_as_feedback_unit!
+    end
+  end
 
-      StepValue.transaction do
-        s = Session.find(id)
-        s.step_values.clone_step :feedback_province, feedback_province
-        s.step_values.clone_step :feedback_district, feedback_district
+  desc "Migrate missing session from chatfuel raw data"
+  task migrate_missing_from_raw_data: :ensure_feedback_unit do
+    StepValue.transaction do
+      ::CSV.foreach(Rails.root.join("corrected-data-in-november.csv")) do |row|
+        id, session_id, feedback_unit, feedback_province, feedback_district = row
+        
+        session = Session.find_by(id: id)
+        if session.present?
+          session.step_values.clone_step :feedback_unit, feedback_unit
+          session.step_values.clone_step :feedback_province, feedback_province
+          session.step_values.clone_step :feedback_district, feedback_district
+          puts "cloning #{session.id} is completed!"
+        end
       end
     end
   end

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -17,6 +17,7 @@ namespace :chatfuel do
 
     logs = {}
 
+    Session.record_timestamps = false
     StepValue.transaction do
       ::CSV.foreach(sessions_csv) do |row|
         id, session_id, feedback_unit, feedback_province, feedback_district = row
@@ -29,6 +30,7 @@ namespace :chatfuel do
         end
       end
     end
+    Session.record_timestamps = true
 
     puts "clone logs: "
     puts logs.inspect

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -13,7 +13,7 @@ namespace :chatfuel do
   desc 'Migrate missing session from chatfuel raw data'
   task :migrate_missing_from_raw_data, [:csv_path] => :ensure_feedback_unit do |t, args|
     sessions_csv = Rails.root.join(args[:csv_path].presence || 'corrected_data.csv')
-    raise(StandardError, "#{sessions_csv.to_path} does not exist") unless File.exists?(sessions_csv)
+    abort "#{sessions_csv.to_path} does not exist" unless File.exists?(sessions_csv)
 
     logs = {}
 

--- a/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
+++ b/lib/tasks/migrate_missing_session_from_raw_chatfuel.rake
@@ -1,21 +1,24 @@
 require 'csv'
 
 namespace :chatfuel do
-  desc "Ensure feedback unit is exists"
+  desc 'Ensure feedback unit is exists'
   task ensure_feedback_unit: :environment do
     feedback_unit = Variable.feedback_unit
     if feedback_unit.nil?
-      feedback_unit = Variable.find_by(name: "feedback_unit")
+      feedback_unit = Variable.find_by(name: 'feedback_unit')
       feedback_unit&.mark_as_feedback_unit!
     end
   end
 
-  desc "Migrate missing session from chatfuel raw data"
-  task migrate_missing_from_raw_data: :ensure_feedback_unit do
+  desc 'Migrate missing session from chatfuel raw data'
+  task :migrate_missing_from_raw_data, [:csv_path] => :ensure_feedback_unit do |t, args|
+    sessions_csv = Rails.root.join(args[:csv_path].presence || 'corrected_data.csv')
+    raise(StandardError, "#{sessions_csv.to_path} does not exist") unless File.exists?(sessions_csv)
+
     logs = {}
 
     StepValue.transaction do
-      ::CSV.foreach(Rails.root.join("corrected-data-in-november.csv")) do |row|
+      ::CSV.foreach(sessions_csv) do |row|
         id, session_id, feedback_unit, feedback_province, feedback_district = row
         session = Session.find_by(id: id)
         if session.present?

--- a/notes/migrate_missing_sessions_from_raw_chatfuel.md
+++ b/notes/migrate_missing_sessions_from_raw_chatfuel.md
@@ -17,8 +17,9 @@ In order to download chatfuel raw session data go to
 2. Import raw chatfuel data into a [google spreadsheet](https://docs.google.com/spreadsheets/d/1hXPUAIhfPHOf7c2HiiUpLhm17wn0YKdVLwK1lEnxozU/edit#gid=0)
 3. Next, dump sessions data(see in scripts section) from database and import into the same spreadsheet in different tab
 4. Correct data using vlookup
-5. Export the corrected sessions
-6. Run rake task (see in scripts section) to check and clone appropriate step value
+5. Export the corrected sessions into the root project directory
+6. Run rake task (see in scripts section) to check and clone appropriate step value,
+   by default, it is expected to there is a file name `corrected-data.csv` if not, you have to explicityly provide the corrected csv file, otherwise it raises an error.
 
 ## Thing to keep in mind when correcting the data
 
@@ -69,5 +70,7 @@ SELECT s.id, s.session_id,
 2. After corrected sessions, run the following to migrate the missing step values that are missing
 
 ```
-rails chatfuel:migrate_missing_from_raw_data
+rails chatfuel:migrate_missing_from_raw_data # expected to have corrected-data.csv in root directory
+or
+rails chatfuel:migrate_missing_from_raw_data['path/to/corrected-data.csv']
 ```

--- a/notes/migrate_missing_sessions_from_raw_chatfuel.md
+++ b/notes/migrate_missing_sessions_from_raw_chatfuel.md
@@ -1,0 +1,34 @@
+## Story
+
+Why do some sessions missing?
+
+Some sessions are completely lose from step values (currently cannot find the root cause yet), therefore, we need to download raw data from chatfuel and manually clone into step values.
+
+In order to download chatfuel raw session data go to
+
+. Goto chatfuel dashboard
+. Select the bot
+. Goto people tab
+. Export users
+
+## Howto
+
+1. After download raw chatfuel data
+2. Import raw chatfuel data into a [google spreadsheet](https://docs.google.com/spreadsheets/d/1hXPUAIhfPHOf7c2HiiUpLhm17wn0YKdVLwK1lEnxozU/edit#gid=0)
+3. Next, dump sessions data from database and import into the same spreadsheet in different tab
+4. Correct data using vlookup
+5. Export the corrected sessions
+6. Run rake task to check and clone appropriate step value
+
+## Thing to keep in mind when correcting the data
+
+1. correct flow hierachy
+   eg. `feedback unit` -> `feedback province` -> `feedback district`
+   this mean that `feedback district` **CANNOT** be exists without `feedback unit` and `feedback province`
+   but `feedback unit` **CAN** be exists without `feedback province` and `feedback district`
+
+2. consistent location
+   eg. feedback province = 02, feedback district = 02xx
+
+3. OWSU location
+   eg. feedback district must ends with xx99

--- a/notes/migrate_missing_sessions_from_raw_chatfuel.md
+++ b/notes/migrate_missing_sessions_from_raw_chatfuel.md
@@ -19,7 +19,7 @@ In order to download chatfuel raw session data go to
 4. Correct data using vlookup
 5. Export the corrected sessions into the root project directory
 6. Run rake task (see in scripts section) to check and clone appropriate step value,
-   by default, it is expected to there is a file name `corrected-data.csv` if not, you have to explicityly provide the corrected csv file, otherwise it raises an error.
+   by default, it is expected to a file named `corrected-data.csv` if not, you have to explicitly provide the corrected csv file, otherwise it raises an error.
 
 ## Thing to keep in mind when correcting the data
 

--- a/notes/migrate_missing_sessions_from_raw_chatfuel.md
+++ b/notes/migrate_missing_sessions_from_raw_chatfuel.md
@@ -15,10 +15,10 @@ In order to download chatfuel raw session data go to
 
 1. After download raw chatfuel data
 2. Import raw chatfuel data into a [google spreadsheet](https://docs.google.com/spreadsheets/d/1hXPUAIhfPHOf7c2HiiUpLhm17wn0YKdVLwK1lEnxozU/edit#gid=0)
-3. Next, dump sessions data from database and import into the same spreadsheet in different tab
+3. Next, dump sessions data(see in scripts section) from database and import into the same spreadsheet in different tab
 4. Correct data using vlookup
 5. Export the corrected sessions
-6. Run rake task to check and clone appropriate step value
+6. Run rake task (see in scripts section) to check and clone appropriate step value
 
 ## Thing to keep in mind when correcting the data
 
@@ -32,3 +32,42 @@ In order to download chatfuel raw session data go to
 
 3. OWSU location
    eg. feedback district must ends with xx99
+
+## Scripts
+
+1. Dump chatbots sessions who provide incompleted feedback in November
+   Note: completed feedback has to answer feedback unit, feedback province, feedback district
+
+```
+docker exec -i chatfuel_db_1 psql -U postgres -d chatfuel_development -c "Copy (
+  WITH feedback_sessions AS (
+  SELECT s.id
+    FROM sessions s
+        INNER JOIN step_values st on s.id = st.session_id
+        INNER JOIN variables v on st.variable_id=v.id
+        WHERE v.name IN ('feedback_unit', 'feedback_province', 'feedback_district')
+        AND DATE(s.engaged_at) BETWEEN '2021-11-01' AND '2021-11-30' AND
+        s.platform_name='Messenger'
+        GROUP BY s.id
+        HAVING COUNT(*) < 3
+)
+
+SELECT s.id, s.session_id,
+  MAX(CASE WHEN v.name = 'feedback_unit' THEN vv.raw_value END) feedback_unit,
+  MAX(CASE WHEN v.name = 'feedback_province' THEN vv.raw_value END) feedback_province,
+  MAX(CASE WHEN v.name = 'feedback_district' THEN vv.raw_value END) feedback_district
+  FROM sessions s
+
+  INNER JOIN step_values st ON s.id=st.session_id
+  INNER JOIN variables v ON st.variable_id=v.id
+  INNER JOIN variable_values vv ON st.variable_value_id=vv.id
+  WHERE s.id IN ( SELECT id FROM feedback_sessions )
+  GROUP BY s.id
+  ORDER BY s.session_id) To STDOUT With CSV HEADER DELIMITER ',';" > feedback_sessions.csv
+```
+
+2. After corrected sessions, run the following to migrate the missing step values that are missing
+
+```
+rails chatfuel:migrate_missing_from_raw_data
+```

--- a/notes/sql/get_5999th_6000th_6001th_sessions.md
+++ b/notes/sql/get_5999th_6000th_6001th_sessions.md
@@ -1,0 +1,14 @@
+## Story
+
+Get the sessions of 5999th, 6000th, 6001th.
+
+```sql
+SELECT session_id, created_at FROM (
+  SELECT DISTINCT ON (session_id) session_id, created_at
+  FROM sessions
+  ORDER BY session_id, created_at ASC
+) t
+ORDER BY created_at ASC
+offset 5998
+LIMIT 3;
+```

--- a/notes/sql/top_2_latest_main_dbs_access_by_each_platform.md
+++ b/notes/sql/top_2_latest_main_dbs_access_by_each_platform.md
@@ -1,0 +1,28 @@
+## Story
+
+Get top 2 latest sessions who access to `main_dbs` in verboice and messenger
+
+```sql
+select * from (
+  SELECT sessions.id, sessions.session_id,
+    platform_name, sessions.created_at ,
+    gender,
+    rank() over ( partition by platform_name order by sessions.created_at desc)
+    FROM "sessions"
+    INNER JOIN "step_values"
+    ON "step_values"."session_id" = "sessions"."id"
+    WHERE "sessions"."gender" = 'female' AND
+          -- variable_id=33 => owso_info
+          "step_values"."variable_id" = 33 AND
+          "step_values"."variable_value_id" IN (
+              SELECT "variable_values"."id" FROM "variable_values"
+                WHERE "variable_values"."variable_id" = 33
+                -- raw_value = 2 (verboice)
+                -- raw_value = 'main_dbs' (chatbot)
+                AND "variable_values"."raw_value" IN ('2', 'main_dbs')
+                ORDER BY "variable_values"."mapping_value_en" ASC
+            )
+      ORDER BY "sessions"."created_at" DESC
+-- top 2
+) tmp where rank <=2;
+```


### PR DESCRIPTION
- [x] clone missing feedback steps ( feedback unit, feedback province, feedback district )
- [x] add note for common sql queries

### Note

**ENGAGED_AT_TIMSTAMPS** : need to be **disabled** during migration and have to **enable** it back _after finish migration_ because the migration will trigger callback to update session's engaged_at that CAUSE SERIOUS WRONG REPORT TIMESTAMP.

it should run in conjunction with `migrate_missing_feedback_location` to make sure sessions's feedback is updated properly in case execution halt cause by callback

```ruby
# this migration used to clone missing feedback location that corrected manually into step values ( because it is lost from step values so we do it manually in google spreadsheet )
rails 'chatfuel:migrate_missing_from_raw_data["path/to/corrected_in_november.csv"]'

# this migration used to update session's feedback location ( in this case we assumed that step values is already exist but does not properly update session's feedback province or feedback district
rails 'session:migrate_missing_feedback_location["2021-11-01", "2021-11-30"]'

```